### PR TITLE
remove todo-comments config

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -301,32 +301,6 @@ theme.plugins = {
 	-- https://github.com/nvim-telescope/telescope.nvim
 	TelescopeBorder = { fg = p.subtle },
 
-	-- todo-comments.nvim
-	-- https://github.com/folke/todo-comments.nvim
-	TodoBgFIX = { fg = '#000000', bg = p.love },
-	TodoFgFIX = { fg = p.love, bg = p.base },
-	TodoSignFIX = { fg = p.love, bg = p.base },
-
-	TodoBgTODO = { fg = '#000000', bg = p.rose },
-	TodoFgTODO = { fg = p.rose, bg = p.base },
-	TodoSignTODO = { fg = p.rose, bg = p.base },
-
-	TodoBgHACK = { fg = '#ffffff', bg = p.pine },
-	TodoFgHACK = { fg = p.pine, bg = p.base },
-	TodoSignHACK = { fg = p.pine, bg = p.base },
-
-	TodoBgWARN = { fg = '#000000', bg = p.gold },
-	TodoFgWARN = { fg = p.gold, bg = p.base },
-	TodoSignWARN = { fg = p.gold, bg = p.base },
-
-	TodoBgPERF = { fg = '#000000', bg = p.foam },
-	TodoFgPERF = { fg = p.foam, bg = p.base },
-	TodoSignPERF = { fg = p.foam, bg = p.base },
-
-	TodoBgNOTE = { fg = '#000000', bg = p.iris },
-	TodoFgNOTE = { fg = p.iris, bg = p.base },
-	TodoSignNOTE = { fg = p.iris, bg = p.base },
-
 	-- which-key.nvim
 	-- https://github.com/folke/which-key.nvim
 	WhichKey = { fg = p.iris },

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,6 @@ require('lualine').setup({
 - [Modes](https://github.com/mvllow/modes.nvim)
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
 - [WhichKey](https://github.com/folke/which-key.nvim)
-- [Todo Comments](https://github.com/folke/todo-comments.nvim)
 - [Lualine](https://github.com/hoob3rt/lualine.nvim)
 
 ## Gallery


### PR DESCRIPTION
Colors are set by default in todo-comments. 

Overriding these colors blocked default ["wide" highlight style](https://github.com/folke/todo-comments.nvim/blob/808a2e524b3720804716a99fd900986b9d727d4d/README.md#%EF%B8%8F-configuration) behavior:

```lua
highlight = {
 keyword = "wide",  -- "fg", "bg", "wide" or empty. (wide is the same as bg, but will also highlight surrounding characters)
}
```