### PR TITLE
Fix conceal highlight

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -14,7 +14,7 @@ end
 
 theme.base = {
 	ColorColumn = { bg = p.highlight_overlay },
-	-- Conceal = {},
+    Conceal = { bg = p.none },
 	-- Cursor = {},
 	CursorColumn = { bg = p.highlight },
 	-- CursorIM = {},


### PR DESCRIPTION
This MR improves the highlight of concealed text. Here's an example:

| Before | After |
| --- | --- |
| ![Screenshot_20210824_220536](https://user-images.githubusercontent.com/58810330/130682677-d1b5deed-075a-4a9f-934b-d700c9d5a9eb.png) | ![Screenshot_20210824_220450](https://user-images.githubusercontent.com/58810330/130682728-7aa4ec45-8e0d-4101-98e4-4baf5e01b0d1.png) |

