### PR TITLE
feat: add galaxyline color theme, see notes in readme

### DIFF
--- a/lua/rose-pine/galaxyline/theme.lua
+++ b/lua/rose-pine/galaxyline/theme.lua
@@ -1,0 +1,19 @@
+local present, galaxyline_colors = pcall(require, "galaxyline.themes.colors")
+if not present then
+  return
+end
+
+local palette = require("rose-pine.palette")
+
+galaxyline_colors["rose-pine"] = {
+  bg = palette.overlay,
+  fg = palette.text,
+  fg_alt = palette.subtle,
+  yellow = palette.gold,
+  cyan = palette.foam,
+  green = palette.inactive,
+  orange = palette.rose,
+  magenta = palette.iris,
+  blue = palette.foam,
+  red = palette.love,
+}

--- a/lua/rose-pine/util.lua
+++ b/lua/rose-pine/util.lua
@@ -55,6 +55,9 @@ function util.load()
 	for group, colors in pairs(theme.plugins) do
 		util.highlight(group, colors)
 	end
+
+	-- Load galaxyline theme
+	require("rose-pine.galaxyline.theme")
 end
 
 return util

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,19 @@ require('lualine').setup({
 })
 ```
 
+Otherwise if you use [galaxyline](https://github.com/glepnir/galaxyline.nvim)
+
+```lua
+-- This should be in your galaxyline configuration file
+local colors = require("galaxyline.themes.colors")["rose-pine"]
+```
+
+> **IMPORTANT**:
+> 
+> 1. This requires [NTBBloodbath's galaxyline fork](https://github.com/NTBBloodbath/galaxyline.nvim) in order to work.
+> 
+> 2. You can see the list of available colors [here](https://github.com/NTBBloodbath/galaxyline.nvim/blob/main/docs/themes.md#colors-standards).
+
 ## Plugin Support
 
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)


### PR DESCRIPTION
Hey, first of all thanks for this very pleasant colorscheme, I use it sometimes haha

I would love to see rose-pine vibes on my galaxyline too when using it, that's why I added this, but you could be thinking "But galaxyline doesn't allow this" well I added this feature on my own fork. Hopefully it will be recognized after a while and my changes merged to upstream once glepnir appears again lol.

This is an screenshot of how it looks like on my galaxyline setup

![image](https://user-images.githubusercontent.com/36456999/133804588-ac030fb7-3208-4d22-8129-c326f554f01d.png)

Added the proper notes about the galaxyline theme in README, let me know if something should be changed.

Regards