### PR TITLE
Fix Lsp hightlight bug

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -142,6 +142,31 @@ theme.base = {
 	LspReferenceText = { fg = p.rose, bg = p.highlight },
 	LspReferenceRead = { fg = p.rose, bg = p.highlight },
 	LspReferenceWrite = { fg = p.rose, bg = p.highlight },
+
+	--Lsp color groups for nvim 0.5.x
+	LspDiagnosticsSignWarning =            { link = "DiagnosticSignWarn" },
+	LspDiagnosticsDefaultWarning =         { link = "DiagnosticDefaultWarn" },
+	LspDiagnosticsFloatingWarning =        { link = "DiagnosticFloatingWarn" },
+	LspDiagnosticsVirtualTextWarning =     { link = "DiagnosticVirtualTextWarn" },
+	LspDiagnosticsUnderlineWarning =       { link = "DiagnosticUnderlineWarn" },
+
+	LspDiagnosticsSignHint =               { link = "DiagnosticSignHint" },
+	LspDiagnosticsDefaultHint =            { link = "DiagnosticDefaultHint" },
+	LspDiagnosticsVirtualTextHint =        { link = "DiagnosticFloatingHint" },
+	LspDiagnosticsFloatingHint =           { link = "DiagnosticVirtualTextHint" },
+	LspDiagnosticsUnderlineHint =          { link = "DiagnosticUnderlineHint" },
+
+	LspDiagnosticsSignError =              { link = "DiagnosticSignError" },
+	LspDiagnosticsDefaultError =           { link = "DiagnosticDefaultError" },
+	LspDiagnosticsFloatingError =          { link = "DiagnosticFloatingError" },
+	LspDiagnosticsVirtualTextError =       { link = "DiagnosticVirtualTextError" },
+	LspDiagnosticsUnderlineError =         { link = "DiagnosticUnderlineError" },
+
+	LspDiagnosticsSignInformation =        { link = "DiagnosticSignInfo" },
+	LspDiagnosticsDefaultInformation =     { link = "DiagnosticDefaultInfo" },
+	LspDiagnosticsFloatingInformation =    { link = "DiagnosticFloatingInfo" },
+	LspDiagnosticsVirtualTextInformation = { link = "DiagnosticVirtualTextInfo" },
+	LspDiagnosticsUnderlineInformation =   { link = "DiagnosticUnderlineInfo" },
 }
 
 function theme.load_terminal()

--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -115,28 +115,28 @@ theme.base = {
 	htmlTagName = { fg = p.foam },
 
 	DiagnosticDefaultHint = { fg = p.iris },
-	DiagnosticDefaultInformation = { fg = p.foam },
-	DiagnosticDefaultWarning = { fg = p.gold },
+	DiagnosticDefaultInfo = { fg = p.foam },
+	DiagnosticDefaultWarn = { fg = p.gold },
 	DiagnosticDefaultError = { fg = p.love },
 
 	DiagnosticFloatingHint = { fg = p.iris },
-	DiagnosticFloatingInformation = { fg = p.foam },
-	DiagnosticFloatingWarning = { fg = p.gold },
+	DiagnosticFloatingInfo = { fg = p.foam },
+	DiagnosticFloatingWarn = { fg = p.gold },
 	DiagnosticFloatingError = { fg = p.love },
 
 	DiagnosticSignHint = { fg = p.iris },
-	DiagnosticSignInformation = { fg = p.foam },
-	DiagnosticSignWarning = { fg = p.gold },
+	DiagnosticSignInfo = { fg = p.foam },
+	DiagnosticSignWarn = { fg = p.gold },
 	DiagnosticSignError = { fg = p.love },
 
 	DiagnosticUnderlineHint = { style = 'undercurl', sp = p.iris },
-	DiagnosticUnderlineInformation = { style = 'undercurl', sp = p.foam },
-	DiagnosticUnderlineWarning = { style = 'undercurl', sp = p.gold },
+	DiagnosticUnderlineInfo = { style = 'undercurl', sp = p.foam },
+	DiagnosticUnderlineWarn = { style = 'undercurl', sp = p.gold },
 	DiagnosticUnderlineError = { style = 'undercurl', sp = p.love },
 
 	DiagnosticVirtualTextHint = { fg = p.iris },
-	DiagnosticVirtualTextInformation = { fg = p.foam },
-	DiagnosticVirtualTextWarning = { fg = p.gold },
+	DiagnosticVirtualTextInfo = { fg = p.foam },
+	DiagnosticVirtualTextWarn = { fg = p.gold },
 	DiagnosticVirtualTextError = { fg = p.love },
 
 	LspReferenceText = { fg = p.rose, bg = p.highlight },


### PR DESCRIPTION
Since with the arrival of nvim 0.6.x changes were made to the names of the lsp hightlight groups, this PR presents a brief solution by correcting the erroneous names of the misspelled groups in the theme, and adding the nvim 0.5.x groups (making links to the already defined LSP colors).
An example of this is presented below:

- Before fixing the problem:

![no-color](https://user-images.githubusercontent.com/65829671/134622137-60605f6a-3696-452a-86fd-923a3d58ca86.png)

- After fixing the problem:

![color](https://user-images.githubusercontent.com/65829671/134622159-318a7c01-a083-43d7-b531-886f38d02979.png)

- New highlight groups defined in nvim 0.6.x

![image](https://user-images.githubusercontent.com/65829671/134622434-9bcc7d89-9e8d-481a-acb1-c0ac39c0dc48.png)

Conclusion: When the groups are not defined, the colors are blank because in the theme loading function there is a "hightligt clear", which makes them disappear completely and they are not redefined with the custom colors of the colorscheme because the group names defined in it do not match the lsp highlight groups.

