### PR TITLE
feat: add highlight for nvim_cmp

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -342,7 +342,7 @@ theme.plugins = {
 	CmpItemKind = { fg = p.iris },
 	CmpItemAbbr = { fg = p.subtle },
 	CmpItemAbbrMatch = { fg = p.text, style = 'bold' },
-  CmpItemAbbrMatchFuzzy = { fg = p.text, style = 'bold' },
+	CmpItemAbbrMatchFuzzy = { fg = p.text, style = 'bold' },
 	CmpItemAbbrDeprecated = { fg = p.subtle, style = 'strikethrough' },
 }
 

--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -336,6 +336,14 @@ theme.plugins = {
 	-- indent-blankline.nvim
 	-- https://github.com/lukas-reineke/indent-blankline.nvim
 	IndentBlanklineChar = { fg = p.subtle },
+
+	-- nvim-cmp
+	-- https://github.com/hrsh7th/nvim-cmp
+	CmpItemKind = { fg = p.iris },
+	CmpItemAbbr = { fg = p.subtle },
+	CmpItemAbbrMatch = { fg = p.text, style = 'bold' },
+  CmpItemAbbrMatchFuzzy = { fg = p.text, style = 'bold' },
+	CmpItemAbbrDeprecated = { fg = p.subtle, style = 'strikethrough' },
 }
 
 return theme


### PR DESCRIPTION
This feature require nvim_cmp `custom_menu` branch for now. 
See https://github.com/hrsh7th/nvim-cmp/pull/224 for more information.

![](https://user-images.githubusercontent.com/47056144/135102265-a4289784-71c3-40d4-85ec-136037410c42.png)
