### PR TITLE
feat: add bold vertical split line option

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -3,6 +3,7 @@ local p = require('rose-pine.palette')
 local theme = {}
 local maybe_base = p.base
 local maybe_italic = 'italic'
+local maybe_bold_vert_split = { fg = p.overlay }
 
 if vim.g.rose_pine_disable_background then
 	maybe_base = p.none
@@ -10,6 +11,10 @@ end
 
 if vim.g.rose_pine_disable_italics then
 	maybe_italic = nil
+end
+
+if vim.g.rose_pine_bold_vertical_split_line then
+	maybe_bold_vert_split = { fg = p.surface, bg = p.surface }
 end
 
 theme.base = {
@@ -61,7 +66,7 @@ theme.base = {
 	-- TabLineFill = {},
 	-- TabLineSel = {},
 	Title = { fg = p.rose },
-	VertSplit = { fg = p.overlay },
+	VertSplit = maybe_bold_vert_split,
 	Visual = { bg = p.highlight },
 	-- VisualNOS = {},
 	WarningMsg = { fg = p.gold },

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,9 @@ vim.g.rose_pine_disable_italics = false
 -- Use terminal background
 vim.g.rose_pine_disable_background = false
 
+-- Use bold vertical split line
+vim.g.rose_pine_bold_vertical_split_line = true
+
 -- Set colorscheme after options
 vim.cmd('colorscheme rose-pine')
 ```


### PR DESCRIPTION
This PR add an option for user to toggle the VertSplit style, just like [nord.vim](https://www.nordtheme.com/docs/ports/vim/configuration)

![](https://user-images.githubusercontent.com/47056144/135297672-78cc8c53-990f-4822-8c69-94433ef617f8.png)


