### PR TITLE
chore: update `FloatBorder` bg color

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -44,7 +44,7 @@ theme.base = {
 	Directory = { fg = p.foam, bg = p.none },
 	-- EndOfBuffer = {},
 	ErrorMsg = { fg = p.love, style = 'bold' },
-	FloatBorder = { fg = p.subtle, bg = p.surface },
+	FloatBorder = { fg = p.subtle },
 	FoldColumn = {},
 	Folded = { fg = p.text, bg = p.surface },
 	IncSearch = { bg = p.highlight },


### PR DESCRIPTION
I think the border looks cleaner when not setting a bg color.

### Before
![bg](https://user-images.githubusercontent.com/7303830/137636442-8abcd279-5a5a-4ee2-99ba-bd562fb91fa4.png)
### After
![no_bg](https://user-images.githubusercontent.com/7303830/137636446-54f0165d-908b-4389-a114-a423b101211f.png)

