### PR TITLE
Fix neogit highlight and adjust the highlight contrast

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -423,11 +423,11 @@ theme.plugins = {
 
 	-- neogit
 	-- https://github.com/TimUntersberger/neogit
-	NeogitDiffAddhighlight_med = { fg = p.foam, bg = p.highlight_high },
-	NeogitDiffDeletehighlight_med = { fg = p.love, bg = p.highlight_high },
-	NeogitDiffContexthighlight_med = { bg = p.highlight_med },
+	NeogitDiffAddhighlight = { fg = p.foam, bg = p.highlight_high },
+	NeogitDiffDeletehighlight = { fg = p.love, bg = p.highlight_high },
+	NeogitDiffContexthighlight = { bg = p.highlight_med },
 	NeogitHunkHeader = { bg = p.highlight_med },
-	NeogitHunkHeaderhighlight_med = { bg = p.highlight_med },
+	NeogitHunkHeaderhighlight = { bg = p.highlight_med },
 
 	-- VimWiki
 	-- https://github.com/vimwiki/vimwiki

--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -423,11 +423,11 @@ theme.plugins = {
 
 	-- neogit
 	-- https://github.com/TimUntersberger/neogit
-	NeogitDiffAddhighlight = { fg = p.foam, bg = p.highlight_high },
-	NeogitDiffDeletehighlight = { fg = p.love, bg = p.highlight_high },
-	NeogitDiffContexthighlight = { bg = p.highlight_med },
-	NeogitHunkHeader = { bg = p.highlight_med },
-	NeogitHunkHeaderhighlight = { bg = p.highlight_med },
+	NeogitDiffAddhighlight = { fg = p.foam, bg = p.highlight_med },
+	NeogitDiffDeletehighlight = { fg = p.love, bg = p.highlight_med },
+	NeogitDiffContexthighlight = { bg = p.highlight_low },
+	NeogitHunkHeader = { bg = p.highlight_low },
+	NeogitHunkHeaderhighlight = { bg = p.highlight_low },
 
 	-- VimWiki
 	-- https://github.com/vimwiki/vimwiki


### PR DESCRIPTION
After upgrade, I notice that neogit highlight was broke. This PR fixed this issue. And I think the new contrast was too high in `moon` variant, so I made a little adjustment to them, too.

Contrast adjustment

Before
<img width="1440" alt="Screen Shot 2021-12-02 at 10 59 57 AM" src="https://user-images.githubusercontent.com/47056144/144350832-24cdf199-29c4-4e05-905c-2d841c5e5ac3.png">

After
<img width="1440" alt="Screen Shot 2021-12-02 at 11 00 16 AM" src="https://user-images.githubusercontent.com/47056144/144350837-93bd1868-1e67-48aa-b43d-1d3fe4c7bfdd.png">
