### PR TITLE
fix: match Markdown headings for TS plugin

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -290,7 +290,7 @@ local theme = {
 	TSTag = { fg = p.foam },
 	TSTagDelimiter = { fg = p.subtle },
 	TSText = { fg = p.text },
-	-- TSTitle = {},
+	TSTitle = { fg = config.colors.headings.h1, style = 'bold' },
 	-- TSType = {},
 	-- TSTypeBuiltin = {},
 	TSURI = { fg = p.gold },


### PR DESCRIPTION
Improve support for the new experimental [Markdown TreeSitter plugin](https://github.com/MDeiml/tree-sitter-markdown) by matching the `TSTitle` style with the existing Markdown H1 heading. Turns
![before](https://user-images.githubusercontent.com/115270/146064621-f6d4e3ea-3eeb-4134-ae90-ee93b667888d.png)
into this
![after](https://user-images.githubusercontent.com/115270/146064645-0e4694e8-87ee-4fcd-a78f-a2969b279f5b.png)

