### PR TITLE
Add lsp_signature highlight

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -474,6 +474,10 @@ local theme = {
 	TargetWord = { fg = p.iris },
 
 	SagaShadow = { bg = p.overlay },
+
+	-- Lsp_Signature
+	-- https://github.com/ray-x/lsp_signature.nvim
+	LspSignatureActiveParameter = { bg = p.overlay },
 }
 
 vim.g.terminal_color_0 = p.overlay -- black


### PR DESCRIPTION
This adds the lsp_signature highlight:

before:

<img width="636" alt="Capture d’écran 2022-01-04 à 10 12 36" src="https://user-images.githubusercontent.com/5306901/148035998-539c424e-b4f4-4ff6-8385-9baf7af2a4a4.png">

after: 

<img width="665" alt="Capture d’écran 2022-01-04 à 10 12 10" src="https://user-images.githubusercontent.com/5306901/148035950-c5196972-1c62-4864-8cf8-6fcf5c6af67e.png">

