### PR TITLE
add `LspReferenceXXX` highlight group

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -240,6 +240,11 @@ function M.get(config)
 		TSVariable = { fg = p.text, style = styles.italic },
 		TSVariableBuiltin = { fg = p.love },
 
+		-- vim.lsp.buf.document_highlight()
+		LspReferenceText = { bg = p.highlight_med },
+		LspReferenceRead = { bg = p.highlight_med },
+		LspReferenceWrite = { bg = p.highlight_med },
+
 		-- romgrk/barbar.nvim
 		BufferCurrent = { fg = p.text, bg = p.overlay },
 		BufferCurrentIndex = { fg = p.text, bg = p.overlay },


### PR DESCRIPTION
The preview using the following autocommand in LSP `on_attach`

```lua
local group = vim.api.nvim_create_augroup("HighlightReferencesOnCursor")
vim.api.nvim_create_autocmd("CursorHold", {
  group = group,
  callback = vim.lsp.buf.document_highlight,
  buffer = bufnr,
})
vim.api.nvim_create_autocmd({ "CursorMoved", "InsertEnter", "BufLeave" }, {
  group = group,
  callback = vim.lsp.buf.clear_references,
  buffer = bufnr,
})
```

https://user-images.githubusercontent.com/55179750/162728432-094599dc-d7c2-4a8c-82ee-5c474b0d0516.mp4


