### PR TITLE
add `LspCodelensXXX` highlight group

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -245,6 +245,10 @@ function M.get(config)
 		LspReferenceRead = { bg = p.highlight_med },
 		LspReferenceWrite = { bg = p.highlight_med },
 
+		-- lsp-highlight-codelens
+		LspCodeLens = { fg = p.subtle }, -- virtual text of code lens
+		LspCodeLensSeparator = { fg = p.highlight_high }, -- separator between two or more code lens
+
 		-- romgrk/barbar.nvim
 		BufferCurrent = { fg = p.text, bg = p.overlay },
 		BufferCurrentIndex = { fg = p.text, bg = p.overlay },


### PR DESCRIPTION
IMO, code lens text must be sufficiently distinguishable from the `Comment` but still fainter than `Normal` or `Text`
@mvllow what color do you think fit best ?

```text
      LspCodeLens
           |
      +----+----+
      |         |
^^^^^^^^^^^   ^^^^^
▶︎ Run Tests | Debug
            ^
            |
            +---> LspCodeLensSeparator
```

![20220426_040742_full](https://user-images.githubusercontent.com/55179750/165166749-7d51cb1d-b35e-40ef-99ed-64898be11aaf.jpg)