### PR TITLE
Add `CurSearch` highlight group

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -18,6 +18,7 @@ function M.get(config)
 	theme = {
 		ColorColumn = { bg = p.highlight_high },
 		Conceal = { bg = p.none },
+		CurSearch = { link = 'IncSearch' },
 		-- Cursor = {},
 		CursorColumn = { bg = p.highlight_low },
 		-- CursorIM = {},


### PR DESCRIPTION
They recently merged https://github.com/neovim/neovim/pull/18081 which adds this group for the next release 0.8. I think it should probably not cause problems for people using earlier versions since there are highlights for random plugins people may not have.

I'm not a designer at all, so feel free to pick different colors, but I think these work well.

<img width="120" alt="image" src="https://user-images.githubusercontent.com/1973/167017321-d007473e-2367-4949-a225-81a8f3fd1578.png">
<img width="131" alt="image" src="https://user-images.githubusercontent.com/1973/167017337-8bcaac21-d5c0-4a44-a8b9-e6710024fe0d.png">
