### PR TITLE
feat: improve contrast of the `FloatTitle`

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -37,6 +37,7 @@ function M.get(config)
 		-- EndOfBuffer = {},
 		ErrorMsg = { fg = p.love, style = 'bold' },
 		FloatBorder = { fg = groups.border },
+		FloatTitle = { fg = p.muted },
 		FoldColumn = { fg = p.muted },
 		Folded = { fg = p.text, bg = groups.panel },
 		IncSearch = { fg = p.base, bg = p.rose },


### PR DESCRIPTION
close #82 

Give the `FloatTitle` a darker color, such as `muted`:

<img width="523" alt="image" src="https://user-images.githubusercontent.com/4208028/171659158-329dbb65-c606-40d3-9425-d087fdc412c0.png">