### PR TITLE
feat: Add nvim-dap-ui highlight groups

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -433,6 +433,27 @@ function M.get(config)
 		NotifyERRORBorder = { fg = p.love },
 		NotifyERRORTitle = { link = 'NotifyERRORBorder' },
 		NotifyERRORIcon = { link = 'NotifyERRORBorder' },
+
+		-- rcarriga/nvim-dap-ui
+		DapUIVariable = { link = 'Normal' },
+		DapUIValue = { link = 'Normal' },
+		DapUIFrameName = { link = 'Normal' },
+		DapUIThread = { fg = p.gold },
+		DapUIWatchesValue = { link = 'DapUIThread' },
+		DapUIBreakpointsInfo = { link = 'DapUIThread' },
+		DapUIBreakpointsCurrentLine = { fg = p.gold, style = 'bold' },
+		DapUIWatchesEmpty = { fg = p.love },
+		DapUIWatchesError = { link = 'DapUIWatchesEmpty' },
+		DapUIBreakpointsDisabledLine = { fg = p.muted },
+		DapUISource = { fg = p.iris },
+		DapUIBreakpointsPath = { fg = p.foam },
+		DapUIScope = { link = 'DapUIBreakpointsPath' },
+		DapUILineNumber = { link = 'DapUIBreakpointsPath' },
+		DapUIBreakpointsLine = { link = 'DapUIBreakpointsPath' },
+		DapUIFloatBorder = { link = 'DapUIBreakpointsPath' },
+		DapUIStoppedThread = { link = 'DapUIBreakpointsPath' },
+		DapUIDecoration = { link = 'DapUIBreakpointsPath' },
+		DapUIModifiedValue = { fg = p.foam, style = 'bold' },
 	}
 
 	vim.g.terminal_color_0 = p.overlay -- black

--- a/readme.md
+++ b/readme.md
@@ -100,3 +100,4 @@ We welcome and appreciate any help in creating a lovely experience for all.
 
 - [Get highlight groups under cursor](https://github.com/nvim-treesitter/playground#show-treesitter-and-syntax-highlight-groups-under-the-cursor)
 - [Adding new highlight groups](https://github.com/rose-pine/neovim/issues/6#issuecomment-962466323)
+- [Palette reference by name](https://rosepinetheme.com/palette)


### PR DESCRIPTION
Plugin: https://github.com/rcarriga/nvim-dap-ui
Original highlights: https://github.com/r/blob/master/lua/dapui/config/highlights.lua

closes #86 


## before


<img width="286" alt="image" src="https://user-images.githubusercontent.com/1973/179334675-85ae007b-8042-4ee3-8098-3192d6033000.png">

<img width="297" alt="image" src="https://user-images.githubusercontent.com/1973/179334691-82d6a87e-5445-497f-bc27-5cdef32c4e44.png">



## after 
<img width="434" alt="image" src="https://user-images.githubusercontent.com/1973/179375226-59d9368e-fe88-442e-8392-ff0a6939e0ce.png">

<img width="448" alt="image" src="https://user-images.githubusercontent.com/1973/179375223-84876dca-4278-40be-8dcb-ce1d0db921c5.png">
