### PR TITLE
feat: Add neovim :checkhealth highlight groups

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -193,6 +193,11 @@ function M.get(config)
 		DiagnosticVirtualTextInfo = { fg = groups.info },
 		DiagnosticVirtualTextWarn = { fg = groups.warn },
 
+		-- healthcheck
+		healthError = { fg = groups.error },
+		healthSuccess = { fg = groups.info },
+		healthWarning = { fg = groups.warn },
+
 		-- TSAttribute = {},
 		TSBoolean = { link = 'Boolean' },
 		TSCharacter = { link = 'Character' },


### PR DESCRIPTION
Similar to `tokyonight.nvim`'s [implementation here](https://github.com/folke/tokyonight.nvim/blob/66bfc2e8f754869c7b651f3f47a2ee56ae557764/lua/tokyonight/theme.lua#L414). Let me know if you prefer different colors!

## Before:
<img width="954" alt="Screen Shot 2022-10-03 at 9 32 46 AM" src="https://user-images.githubusercontent.com/14964777/193590440-af389683-0729-46b7-a5bc-8cf4123834a1.png">

## After:
<img width="954" alt="Screen Shot 2022-10-03 at 9 35 27 AM" src="https://user-images.githubusercontent.com/14964777/193591013-5ded4d87-269b-418b-8d57-7f15079b076a.png">
