### PR TITLE
fix: indent-blankline missing hlGroups

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -376,6 +376,8 @@ function M.get(config)
 
 		-- luka-reineke/indent-blankline.nvim
 		IndentBlanklineChar = { fg = p.muted },
+		IndentBlanklineSpaceChar = { fg = p.muted },
+		IndentBlanklineSpaceCharBlankline = { fg = p.muted },
 
 		-- hrsh7th/nvim-cmp
 		CmpItemAbbr = { fg = p.subtle },


### PR DESCRIPTION
The hlGroups `IndentBlanklineSpaceChar` and `IndentBlanklineSpaceCharBlankline` were missing from the theme, resulting in `listchars` showing up in a default blue colour.