### PR TITLE
Add popup title bar color for NeoTree

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -328,6 +328,9 @@ function M._load(options)
 	h('NvimTreeSpecialFile', { link = 'NvimTreeNormal' })
 	h('NvimTreeWindowPicker', { fg = p.love, bg = p.love, blend = 10 })
 
+  -- nvim-neo-tree/neo-tree.nvim
+  h('NeoTreeTitleBar', { fg = p.surface, bg = p.pine })
+
 	-- folke/which-key.nvim
 	h('WhichKey', { fg = p.iris })
 	h('WhichKeyGroup', { fg = p.foam })


### PR DESCRIPTION
I think the rest of the colors for neo-tree seem fine (at least the ones I've ran across so far in the last couple of weeks since switching to it), but the title bar on the popups were a bit hard to read.

before:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/1973/223737070-fa87aabd-42a4-47bc-bd59-b1a58c4dea02.png">
<img width="533" alt="image" src="https://user-images.githubusercontent.com/1973/223737125-6ca3ff09-a25a-49e5-b0d2-30bd0a0d4520.png">

after:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/1973/223737214-d980fd5b-a009-49f1-bf05-94acbec74194.png">
<img width="467" alt="image" src="https://user-images.githubusercontent.com/1973/223737326-f0b06b37-6b8d-4862-80ef-5a1ee3951632.png">

