### PR TITLE
feat: highlights for goolord/alpha-nvim

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -340,8 +340,8 @@ function M._load(options)
 	h('NvimTreeSpecialFile', { link = 'NvimTreeNormal' })
 	h('NvimTreeWindowPicker', { fg = p.love, bg = p.love, blend = 10 })
 
-  -- nvim-neo-tree/neo-tree.nvim
-  h('NeoTreeTitleBar', { fg = p.surface, bg = p.pine })
+	-- nvim-neo-tree/neo-tree.nvim
+	h('NeoTreeTitleBar', { fg = p.surface, bg = p.pine })
 
 	-- folke/which-key.nvim
 	h('WhichKey', { fg = p.iris })

--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -542,6 +542,12 @@ function M._load(options)
 	h('MiniIndentscopeSymbol', { fg = p.highlight_med })
 	h('MiniIndentscopeSymbolOff', { fg = p.highlight_med })
 
+	-- goolord/alpha-nvim
+	h('AlphaHeader', { fg = p.pine })
+	h('AlphaButtons', { fg = p.foam })
+	h('AlphaShortcut', { fg = p.rose })
+	h('AlphaFooter', { fg = p.gold })
+
 	vim.g.terminal_color_0 = p.overlay -- black
 	vim.g.terminal_color_8 = p.subtle -- bright black
 	vim.g.terminal_color_1 = p.love -- red


### PR DESCRIPTION
example using [LazyVim](https://www.lazyvim.org/)'s built-in UI that uses [goolord/alpha-nvim](https://github.com/goolord/alpha-nvim) under the hood:

<img width="929" alt="Screen Shot 2023-03-18 at 11 11 59 PM" src="https://user-images.githubusercontent.com/1477317/226151588-256714e8-791d-42e1-bb92-1342d93d2105.png">
