### PR TITLE
fix: reset `@lsp.type.comment`

### DIFF
--- a/lua/rose-pine/theme.lua
+++ b/lua/rose-pine/theme.lua
@@ -264,6 +264,7 @@ function M._load(options)
 	h('@namespace', { link = '@include' })
 
 	-- LSP Semantic Token Groups
+	h('@lsp.type.comment', {})
 	h('@lsp.type.enum', { link = '@type' })
 	h('@lsp.type.keyword', { link = '@keyword' })
 	h('@lsp.type.interface', { link = '@interface' })


### PR DESCRIPTION
Linking `@lsp.type.comment` to `Comment` (default behavior if not set)
or `@comment` makes TODO comments look like normal comments.

Before

![20230419_000545](https://user-images.githubusercontent.com/55179750/232839726-90dcb31d-1aed-4f70-85c3-35bebac496e1.jpeg)

After

![20230419_000616](https://user-images.githubusercontent.com/55179750/232839809-9f2a736e-08b7-4f5b-87f8-d2c5b11ca810.jpeg)
