### PR TITLE
docs: add `lualine.nvim` theme guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,8 +117,9 @@ require('rose-pine').setup({
 -- Set colorscheme after options
 vim.cmd('colorscheme rose-pine')
 ```
+
 > [!NOTE]
-> For more information on customizing certain plugins such as [Lualine](https://github.com/nvim-lualine/lualine.nvim), [Bufferline](https://github.com/akinsho/bufferline.nvim), and [toggleterm](https://github.com/akinsho/toggleterm.nvim), please [visit the Rose Pine Wiki](https://github.com/rose-pine/neovim/wiki).
+> Visit the [wiki](https://github.com/rose-pine/neovim/wiki) for [plugin configurations](https://github.com/rose-pine/neovim/wiki/Plugin-configurations) and [recipes](https://github.com/rose-pine/neovim/wiki/Recipes).
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,7 @@ require('rose-pine').setup({
 -- Set colorscheme after options
 vim.cmd('colorscheme rose-pine')
 ```
-**[lualine.nvim](https://github.com/wbthomason/packer.nvim)**
+**[lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)**
 ```lua
 require('lualine').setup {
   options = {

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,17 @@ require('rose-pine').setup({
 -- Set colorscheme after options
 vim.cmd('colorscheme rose-pine')
 ```
+**[lualine.nvim](https://github.com/wbthomason/packer.nvim)**
+```lua
+require('lualine').setup {
+  options = {
+    -- ... your lualine config
+    --- @usage 'rose-pine'|'rose-pine-alt'
+    theme = 'rose-pine',
+    -- ... your lualine config
+  }
+}
+```
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -117,17 +117,8 @@ require('rose-pine').setup({
 -- Set colorscheme after options
 vim.cmd('colorscheme rose-pine')
 ```
-**[lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)**
-```lua
-require('lualine').setup {
-  options = {
-    -- ... your lualine config
-    --- @usage 'rose-pine'|'rose-pine-alt'
-    theme = 'rose-pine',
-    -- ... your lualine config
-  }
-}
-```
+> [!NOTE]
+> For more information on customizing certain plugins such as [Lualine](https://github.com/nvim-lualine/lualine.nvim), [Bufferline](https://github.com/akinsho/bufferline.nvim), and [toggleterm](https://github.com/akinsho/toggleterm.nvim), please [visit the Rose Pine Wiki](https://github.com/rose-pine/neovim/wiki).
 
 ## Contributing
 


### PR DESCRIPTION
I had to find this information within a Reddit Post, and I thought it was relevant that the documentation for the theme itself had this available