### PR TITLE
feat: add new treesitter highlights

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -92,6 +92,8 @@ local function set_highlights()
 		WarningMsg = { fg = groups.warn, bold = styles.bold },
 		-- Whitespace = {},
 		WildMenu = { link = "IncSearch" },
+		WinBar = { fg = palette.subtle, bg = groups.panel },
+		WinBarNC = { fg = palette.muted, bg = groups.panel, blend = 60 },
 		WinSeparator = { fg = groups.border },
 
 		DiagnosticError = { fg = groups.error },

--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -5,7 +5,11 @@ local function set_highlights()
 	local utilities = require("rose-pine.utilities")
 	local palette = require("rose-pine.palette")
 	local styles = config.options.styles
-	local groups = config.options.groups
+
+	local groups = {}
+	for group, color in pairs(config.options.groups) do
+		groups[group] = utilities.parse_color(color)
+	end
 
 	local function make_border(fg)
 		fg = fg or groups.border
@@ -16,10 +20,8 @@ local function set_highlights()
 		}
 	end
 
-	local function make_title(fg)
-		fg = fg or palette.foam
-		return { fg = styles.bold and palette.text or fg, bold = styles.bold }
-	end
+	local adaptive_title = { fg = styles.bold and palette.text or palette.foam, bold = styles.bold }
+	local adaptive_border = make_border()
 
 	local highlights = {}
 	local legacy_highlights = {
@@ -96,10 +98,10 @@ local function set_highlights()
 		diffAdded = { link = "DiffAdd" },
 		diffChanged = { link = "DiffChange" },
 		diffRemoved = { link = "DiffDelete" },
-		Directory = make_title(),
+		Directory = adaptive_title,
 		-- EndOfBuffer = {},
 		ErrorMsg = { fg = groups.error, bold = styles.bold },
-		FloatBorder = make_border(),
+		FloatBorder = adaptive_border,
 		FloatTitle = { link = "Directory" },
 		FoldColumn = { fg = palette.muted },
 		Folded = { fg = palette.text, bg = groups.panel },
@@ -142,7 +144,7 @@ local function set_highlights()
 		TabLine = { fg = palette.subtle, bg = groups.panel },
 		TabLineFill = { bg = groups.panel },
 		TabLineSel = { fg = palette.text, bg = palette.overlay, bold = styles.bold },
-		Title = make_title(),
+		Title = adaptive_title,
 		VertSplit = { fg = groups.border },
 		Visual = { bg = palette.highlight_med },
 		-- VisualNOS = {},
@@ -238,17 +240,17 @@ local function set_highlights()
 		htmlTagName = { fg = palette.foam },
 
 		markdownDelimiter = { fg = palette.subtle },
-		markdownH1 = { fg = groups.headings.h1, bold = styles.bold },
+		markdownH1 = { fg = groups.h1, bold = styles.bold },
 		markdownH1Delimiter = { link = "markdownH1" },
-		markdownH2 = { fg = groups.headings.h2, bold = styles.bold },
+		markdownH2 = { fg = groups.h2, bold = styles.bold },
 		markdownH2Delimiter = { link = "markdownH2" },
-		markdownH3 = { fg = groups.headings.h3, bold = styles.bold },
+		markdownH3 = { fg = groups.h3, bold = styles.bold },
 		markdownH3Delimiter = { link = "markdownH3" },
-		markdownH4 = { fg = groups.headings.h4, bold = styles.bold },
+		markdownH4 = { fg = groups.h4, bold = styles.bold },
 		markdownH4Delimiter = { link = "markdownH4" },
-		markdownH5 = { fg = groups.headings.h5, bold = styles.bold },
+		markdownH5 = { fg = groups.h5, bold = styles.bold },
 		markdownH5Delimiter = { link = "markdownH5" },
-		markdownH6 = { fg = groups.headings.h6, bold = styles.bold },
+		markdownH6 = { fg = groups.h6, bold = styles.bold },
 		markdownH6Delimiter = { link = "markdownH6" },
 		markdownLinkText = { link = "markdownUrl" },
 		markdownUrl = { fg = groups.link, sp = groups.link, underline = true },
@@ -355,7 +357,7 @@ local function set_highlights()
 		["@markup.strikethrough"] = { strikethrough = true },
 		["@markup.underline"] = { underline = true },
 
-		["@markup.heading"] = make_title(),
+		["@markup.heading"] = adaptive_title,
 
 		["@markup.quote"] = { fg = palette.subtle },
 		["@markup.math"] = { link = "Special" },
@@ -457,7 +459,7 @@ local function set_highlights()
 		NvimTreeNormal = { link = "Normal" },
 		NvimTreeOpenedFile = { fg = palette.text, bg = palette.overlay },
 		NvimTreeOpenedFolderName = { link = "NvimTreeFolderName" },
-		NvimTreeRootFolder = make_title(),
+		NvimTreeRootFolder = adaptive_title,
 		NvimTreeSpecialFile = { link = "NvimTreeNormal" },
 		NvimTreeWindowPicker = { link = "StatusLineTerm" },
 
@@ -543,22 +545,22 @@ local function set_highlights()
 		NeorgHeading5Title = { link = "markdownH5" },
 		NeorgHeading6Prefix = { link = "markdownH6Delimiter" },
 		NeorgHeading6Title = { link = "markdownH6" },
-		NeorgMarkerTitle = make_title(),
+		NeorgMarkerTitle = adaptive_title,
 
 		-- tami5/lspsaga.nvim (fork of glepnir/lspsaga.nvim)
 		DefinitionCount = { fg = palette.rose },
 		DefinitionIcon = { fg = palette.rose },
 		DefintionPreviewTitle = { fg = palette.rose, bold = styles.bold },
-		LspFloatWinBorder = make_border(),
+		LspFloatWinBorder = adaptive_border,
 		LspFloatWinNormal = { bg = groups.panel },
 		LspSagaAutoPreview = { fg = palette.subtle },
 		LspSagaCodeActionBorder = make_border(palette.rose),
 		LspSagaCodeActionContent = { fg = palette.foam },
 		LspSagaCodeActionTitle = { fg = palette.gold, bold = styles.bold },
 		LspSagaCodeActionTruncateLine = { link = "LspSagaCodeActionBorder" },
-		LspSagaDefPreviewBorder = make_border(),
+		LspSagaDefPreviewBorder = adaptive_border,
 		LspSagaDiagnosticBorder = make_border(palette.gold),
-		LspSagaDiagnosticHeader = make_title(),
+		LspSagaDiagnosticHeader = adaptive_title,
 		LspSagaDiagnosticTruncateLine = { link = "LspSagaDiagnosticBorder" },
 		LspSagaDocTruncateLine = { link = "LspSagaHoverBorder" },
 		LspSagaFinderSelection = { fg = palette.gold },
@@ -595,26 +597,26 @@ local function set_highlights()
 		HopUnmatched = { fg = palette.muted },
 
 		-- nvim-telescope/telescope.nvim
-		TelescopeBorder = make_border(),
+		TelescopeBorder = adaptive_border,
 		TelescopeMatching = { fg = palette.rose },
 		TelescopeNormal = { link = "NormalFloat" },
 		TelescopePromptNormal = { link = "TelescopeNormal" },
 		TelescopePromptPrefix = { fg = palette.subtle },
 		TelescopeSelection = { fg = palette.text, bg = palette.overlay },
 		TelescopeSelectionCaret = { fg = palette.rose, bg = palette.overlay },
-		TelescopeTitle = make_title(),
+		TelescopeTitle = adaptive_title,
 
 		-- ibhagwan/fzf-lua
 		FzfLuaNormal = { link = "NormalFloat" },
-		FwzfLuaTitle = make_title(),
-		FzfLuaBorder = make_border(),
+		FwzfLuaTitle = adaptive_title,
+		FzfLuaBorder = adaptive_border,
 		FzfLuaHeaderText = { fg = palette.love },
 		FzfLuaHeaderBind = { fg = palette.rose },
 		FzfLuaBufFlagCur = { fg = palette.subtle },
 		FzfLuaBufFlagAlt = { fg = palette.subtle },
 
 		-- rcarriga/nvim-notify
-		NotifyDEBUGBorder = make_border(),
+		NotifyDEBUGBorder = adaptive_border,
 		NotifyDEBUGIcon = { link = "NotifyDEBUGTitle" },
 		NotifyDEBUGTitle = { fg = palette.muted },
 		NotifyERRORBorder = make_border(groups.error),
@@ -637,7 +639,7 @@ local function set_highlights()
 		DapUIBreakpointsLine = { link = "DapUIBreakpointsPath" },
 		DapUIBreakpointsPath = { fg = palette.foam },
 		DapUIDecoration = { link = "DapUIBreakpointsPath" },
-		DapUIFloatBorder = make_border(),
+		DapUIFloatBorder = adaptive_border,
 		DapUIFrameName = { fg = palette.text },
 		DapUILineNumber = { link = "DapUIBreakpointsPath" },
 		DapUIModifiedValue = { fg = palette.foam, bold = styles.bold },
@@ -763,25 +765,41 @@ local function set_highlights()
 			highlights[group] = highlight
 		end
 	end
-	if config.options.highlight_groups ~= nil and next(config.options.highlight_groups) ~= nil then
-		vim.print(config.options.highlight_groups)
-		for group, options in pairs(config.options.highlight_groups) do
-			local default_opts = highlights[group] or {}
 
-			if (options.inherit == nil or options.inherit) and default_opts ~= nil then
-				options.inherit = nil
-				highlights[group] = vim.tbl_extend("force", default_opts, options)
-			else
-				options.inherit = nil
-				highlights[group] = options
+	-- Reconcile highlights with config
+	if config.options.highlight_groups ~= nil and next(config.options.highlight_groups) ~= nil then
+		for group, highlight in pairs(config.options.highlight_groups) do
+			local existing = highlights[group] or {}
+			local parsed = vim.tbl_extend("force", {}, highlight)
+
+			if highlight.fg ~= nil then
+				parsed.fg = utilities.parse_color(highlight.fg) or highlight.fg
+			end
+			if highlight.bg ~= nil then
+				parsed.bg = utilities.parse_color(highlight.bg) or highlight.bg
+			end
+			if highlight.sp ~= nil then
+				parsed.sp = utilities.parse_color(highlight.sp) or highlight.sp
 			end
 
-			highlights[group] = vim.tbl_extend("force", highlights[group] or {}, options)
+			if (highlight.inherit == nil or highlight.inherit) and existing ~= nil then
+				highlight.inherit = nil
+				highlights[group] = vim.tbl_extend("force", existing, parsed)
+			else
+				highlight.inherit = nil
+				highlights[group] = parsed
+			end
 		end
 	end
+
 	for group, highlight in pairs(highlights) do
-		config.options.before_highlight(group, highlight, palette)
-		utilities.highlight(group, highlight)
+		if config.options.before_highlight ~= nil then
+			config.options.before_highlight(group, highlight, palette)
+		end
+		if highlight.blend ~= nil and (highlight.blend >= 0 and highlight.blend <= 100) and highlight.bg ~= nil then
+			highlight.bg = utilities.blend(highlight.bg, highlight.blend_on or palette.base, highlight.blend / 100)
+		end
+		vim.api.nvim_set_hl(0, group, highlight)
 	end
 
 	--- Terminal

--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -21,7 +21,64 @@ local function set_highlights()
 		return { fg = styles.bold and palette.text or fg, bold = styles.bold }
 	end
 
-	local highlights = {
+	local highlights = {}
+	local legacy_highlights = {
+		["@attribute.diff"] = { fg = palette.gold },
+		["@boolean"] = { link = "Boolean" },
+		["@class"] = { fg = palette.foam },
+		["@conditional"] = { link = "Conditional" },
+		["@field"] = { fg = palette.foam },
+		["@include"] = { link = "Include" },
+		["@interface"] = { fg = palette.foam },
+		["@macro"] = { link = "Macro" },
+		["@method"] = { fg = palette.rose },
+		["@namespace"] = { link = "Include" },
+		["@number"] = { link = "Number" },
+		["@parameter"] = { fg = palette.iris, italic = styles.italic },
+		["@preproc"] = { link = "PreProc" },
+		["@punctuation"] = { fg = palette.subtle },
+		["@punctuation.bracket"] = { link = "@punctuation" },
+		["@punctuation.delimiter"] = { link = "@punctuation" },
+		["@punctuation.special"] = { link = "@punctuation" },
+		["@regexp"] = { link = "String" },
+		["@repeat"] = { link = "Repeat" },
+		["@storageclass"] = { link = "StorageClass" },
+		["@symbol"] = { link = "Identifier" },
+		["@text"] = { fg = palette.text },
+		["@text.danger"] = { fg = groups.error },
+		["@text.diff.add"] = { fg = groups.git_add, bg = groups.git_add, blend = 20 },
+		["@text.diff.delete"] = { fg = groups.git_delete, bg = groups.git_delete, blend = 20 },
+		["@text.emphasis"] = { italic = styles.italic },
+		["@text.environment"] = { link = "Macro" },
+		["@text.environment.name"] = { link = "Type" },
+		["@text.math"] = { link = "Special" },
+		["@text.note"] = { link = "SpecialComment" },
+		["@text.strike"] = { strikethrough = true },
+		["@text.strong"] = { bold = styles.bold },
+		["@text.title"] = { link = "Title" },
+		["@text.title.1.markdown"] = { link = "markdownH1" },
+		["@text.title.1.marker.markdown"] = { link = "markdownH1Delimiter" },
+		["@text.title.2.markdown"] = { link = "markdownH2" },
+		["@text.title.2.marker.markdown"] = { link = "markdownH2Delimiter" },
+		["@text.title.3.markdown"] = { link = "markdownH3" },
+		["@text.title.3.marker.markdown"] = { link = "markdownH3Delimiter" },
+		["@text.title.4.markdown"] = { link = "markdownH4" },
+		["@text.title.4.marker.markdown"] = { link = "markdownH4Delimiter" },
+		["@text.title.5.markdown"] = { link = "markdownH5" },
+		["@text.title.5.marker.markdown"] = { link = "markdownH5Delimiter" },
+		["@text.title.6.markdown"] = { link = "markdownH6" },
+		["@text.title.6.marker.markdown"] = { link = "markdownH6Delimiter" },
+		["@text.underline"] = { underline = true },
+		["@text.uri"] = { fg = groups.link },
+		["@text.warning"] = { fg = groups.warn },
+		["@todo"] = { link = "Todo" },
+
+		-- lukas-reineke/indent-blankline.nvim
+		IndentBlanklineChar = { fg = palette.muted, nocombine = true },
+		IndentBlanklineSpaceChar = { fg = palette.muted, nocombine = true },
+		IndentBlanklineSpaceCharBlankline = { fg = palette.muted, nocombine = true },
+	}
+	local default_highlights = {
 		ColorColumn = { bg = palette.surface },
 		Conceal = { bg = "NONE" },
 		CurSearch = { fg = palette.base, bg = palette.gold },
@@ -157,7 +214,7 @@ local function set_highlights()
 		String = { fg = palette.gold },
 		Structure = { fg = palette.foam },
 		Tag = { fg = palette.foam },
-		Todo = { fg = palette.iris, bg = palette.iris, blend = 20 },
+		Todo = { fg = palette.rose, bg = palette.rose, blend = 20 },
 		Type = { fg = palette.foam },
 		TypeDef = { link = "Type" },
 		Underlined = { fg = palette.iris, underline = true },
@@ -209,93 +266,144 @@ local function set_highlights()
 		mkdRule = { fg = palette.subtle },
 		mkdURL = { link = "markdownUrl" },
 
-		["@attribute.diff"] = { fg = palette.gold },
-		["@boolean"] = { link = "Boolean" },
+		--- Identifiers
+		["@variable"] = { fg = palette.text, italic = styles.italic },
+		["@variable.builtin"] = { fg = palette.text, bold = styles.bold },
+		["@variable.parameter"] = { fg = palette.iris, italic = styles.italic },
+		["@variable.member"] = { fg = palette.foam },
+
+		["@constant"] = { fg = palette.gold },
+		["@constant.builtin"] = { fg = palette.gold, bold = styles.bold },
+		["@constant.macro"] = { fg = palette.gold },
+
+		["@module"] = { fg = palette.text },
+		["@module.builtin"] = { fg = palette.text, bold = styles.bold },
+		["@label"] = { link = "Label" },
+
+		--- Literals
+		["@string"] = { link = "String" },
+		-- ["@string.documentation"] = {},
+		["@string.regexp"] = { fg = palette.iris },
+		["@string.escape"] = { fg = palette.pine },
+		["@string.special"] = { link = "String" },
+		["@string.special.symbol"] = { link = "Identifier" },
+		["@string.special.url"] = { fg = groups.link },
+		-- ["@string.special.path"] = {},
+
 		["@character"] = { link = "Character" },
 		["@character.special"] = { link = "Character" },
-		["@class"] = { fg = palette.foam },
-		["@comment"] = { link = "Comment" },
-		["@conditional"] = { link = "Conditional" },
-		["@constant"] = { link = "Constant" },
-		["@constant.builtin"] = { fg = palette.love },
-		["@constant.macro"] = { link = "Constant" },
-		["@constructor"] = { fg = palette.foam },
-		["@field"] = { fg = palette.foam },
-		["@function"] = { link = "Function" },
-		["@function.builtin"] = { fg = palette.love },
+
+		["@boolean"] = { link = "Boolean" },
+		["@number"] = { link = "Number" },
+		["@number.float"] = { link = "Number" },
+
+		--- Types
+		["@type"] = { fg = palette.foam },
+		["@type.builtin"] = { fg = palette.foam, bold = styles.bold },
+		-- ["@type.definition"] = {},
+		-- ["@type.qualifier"] = {},
+
+		-- ["@attribute"] = {},
+		["@property"] = { fg = palette.foam, italic = styles.italic },
+
+		--- Functions
+		["@function"] = { fg = palette.rose },
+		["@function.builtin"] = { fg = palette.rose, bold = styles.bold },
+		-- ["@function.call"] = {},
 		["@function.macro"] = { link = "Function" },
-		["@include"] = { link = "Include" },
-		["@interface"] = { fg = palette.foam },
+		["@function.method"] = { fg = palette.rose },
+		["@function.method.call"] = { fg = palette.iris },
+
+		["@constructor"] = { fg = palette.foam },
+		["@operator"] = { link = "Operator" },
+
+		--- Keywords
 		["@keyword"] = { link = "Keyword" },
+		-- ["@keyword.coroutine"] = {},
+		-- ["@keyword.function"] = {},
 		["@keyword.operator"] = { fg = palette.subtle },
-		["@label"] = { link = "Label" },
+		["@keyword.import"] = { fg = palette.pine },
+		["@keyword.storage"] = { fg = palette.foam },
+		["@keyword.repeat"] = { fg = palette.pine },
+		["@keyword.return"] = { fg = palette.pine },
+		["@keyword.debug"] = { fg = palette.rose },
+		["@keyword.exception"] = { fg = palette.pine },
+		["@keyword.conditional"] = { fg = palette.pine },
+		["@keyword.conditional.ternary"] = { fg = palette.pine },
+		["@keyword.directive"] = { fg = palette.iris },
+		["@keyword.directive.define"] = { fg = palette.iris },
+
+		--- Punctuation
+		["@punctuation.delimiter"] = { fg = palette.subtle },
+		["@punctuation.bracket"] = { fg = palette.subtle },
+		["@punctuation.special"] = { fg = palette.subtle },
+
+		--- Comments
+		["@comment"] = { link = "Comment" },
+		-- ["@comment.documentation"] = {},
+
+		["@comment.error"] = { fg = groups.error },
+		["@comment.warning"] = { fg = groups.warn },
+		["@comment.todo"] = { fg = groups.todo, bg = groups.todo, blend = 20 },
+		["@comment.hint"] = { fg = groups.hint, bg = groups.hint, blend = 20 },
+		["@comment.info"] = { fg = groups.info, bg = groups.info, blend = 20 },
+		["@comment.note"] = { fg = groups.note, bg = groups.note, blend = 20 },
+
+		--- Markup
+		["@markup.strong"] = { bold = styles.bold },
+		["@markup.italic"] = { italic = styles.italic },
+		["@markup.strikethrough"] = { strikethrough = true },
+		["@markup.underline"] = { underline = true },
+
+		["@markup.heading"] = make_title(),
+
+		["@markup.quote"] = { fg = palette.subtle },
+		["@markup.math"] = { link = "Special" },
+		["@markup.environment"] = { link = "Macro" },
+		["@markup.environment.name"] = { link = "@type" },
+
+		-- ["@markup.link"] = {},
+		["@markup.link.label"] = { fg = palette.text },
+		["@markup.link.url"] = { fg = groups.link },
+
+		-- ["@markup.raw"] = { bg = palette.surface },
+		-- ["@markup.raw.block"] = { bg = palette.surface },
+
+		["@markup.list"] = { fg = palette.text },
+		["@markup.list.checked"] = { fg = palette.foam, bg = palette.foam, blend = 10 },
+		["@markup.list.unchecked"] = { fg = palette.text },
+
+		["@diff.plus"] = { fg = groups.git_add, bg = groups.git_add, blend = 20 },
+		["@diff.minus"] = { fg = groups.git_delete, bg = groups.git_delete, blend = 20 },
+		["@diff.delta"] = { bg = groups.git_change, blend = 20 },
+
+		["@tag"] = { link = "Tag" },
+		["@tag.attribute"] = { fg = palette.iris },
+		["@tag.delimiter"] = { fg = palette.subtle },
+
+		--- Non-highlighting captures
+		-- ["@none"] = {},
+		["@conceal"] = { link = "Conceal" },
+
+		-- ["@spell"] = {},
+		-- ["@nospell"] = {},
+
+		--- Semantic
 		["@lsp.type.comment"] = {},
-		["@lsp.type.enum"] = { link = "Type" },
+		["@lsp.type.enum"] = { link = "@type" },
 		["@lsp.type.interface"] = { link = "@interface" },
-		["@lsp.type.keyword"] = { link = "Keyword" },
+		["@lsp.type.keyword"] = { link = "@keyword" },
 		["@lsp.type.namespace"] = { link = "@namespace" },
 		["@lsp.type.parameter"] = { link = "@parameter" },
 		["@lsp.type.property"] = { link = "@property" },
 		["@lsp.type.variable"] = {},
-		["@lsp.typemod.function.defaultLibrary"] = { link = "Special" },
-		["@lsp.typemod.operator.injected"] = { link = "Operator" },
-		["@lsp.typemod.string.injected"] = { link = "String" },
+		["@lsp.typemod.function.defaultLibrary"] = { link = "@function.builtin" },
+		["@lsp.typemod.operator.injected"] = { link = "@operator" },
+		["@lsp.typemod.string.injected"] = { link = "@string" },
 		["@lsp.typemod.variable.defaultLibrary"] = { link = "@variable.builtin" },
 		["@lsp.typemod.variable.injected"] = { link = "@variable" },
-		["@macro"] = { link = "Macro" },
-		["@method"] = { fg = palette.rose },
-		["@namespace"] = { link = "Include" },
-		["@number"] = { link = "Number" },
-		["@operator"] = { link = "Operator" },
-		["@parameter"] = { fg = palette.iris, italic = styles.italic },
-		["@preproc"] = { link = "PreProc" },
-		["@property"] = { fg = palette.foam, italic = styles.italic },
-		["@punctuation"] = { fg = palette.subtle },
-		["@punctuation.bracket"] = { link = "@punctuation" },
-		["@punctuation.delimiter"] = { link = "@punctuation" },
-		["@punctuation.special"] = { link = "@punctuation" },
-		["@regexp"] = { link = "String" },
-		["@repeat"] = { link = "Repeat" },
-		["@storageclass"] = { link = "StorageClass" },
-		["@string"] = { link = "String" },
-		["@string.escape"] = { fg = palette.pine },
-		["@string.special"] = { link = "String" },
-		["@symbol"] = { link = "Identifier" },
-		["@tag"] = { link = "Tag" },
-		["@tag.attribute"] = { fg = palette.iris },
-		["@tag.delimiter"] = { fg = palette.subtle },
-		["@text"] = { fg = palette.text },
-		["@text.danger"] = { fg = groups.error },
-		["@text.diff.add"] = { fg = groups.git_add, bg = groups.git_add, blend = 20 },
-		["@text.diff.delete"] = { fg = groups.git_delete, bg = groups.git_delete, blend = 20 },
-		["@text.emphasis"] = { italic = styles.italic },
-		["@text.environment"] = { link = "Macro" },
-		["@text.environment.name"] = { link = "Type" },
-		["@text.math"] = { link = "Special" },
-		["@text.note"] = { link = "SpecialComment" },
-		["@text.strike"] = { strikethrough = true },
-		["@text.strong"] = { bold = styles.bold },
-		["@text.title"] = { link = "Title" },
-		["@text.title.1.markdown"] = { link = "markdownH1" },
-		["@text.title.1.marker.markdown"] = { link = "markdownH1Delimiter" },
-		["@text.title.2.markdown"] = { link = "markdownH2" },
-		["@text.title.2.marker.markdown"] = { link = "markdownH2Delimiter" },
-		["@text.title.3.markdown"] = { link = "markdownH3" },
-		["@text.title.3.marker.markdown"] = { link = "markdownH3Delimiter" },
-		["@text.title.4.markdown"] = { link = "markdownH4" },
-		["@text.title.4.marker.markdown"] = { link = "markdownH4Delimiter" },
-		["@text.title.5.markdown"] = { link = "markdownH5" },
-		["@text.title.5.marker.markdown"] = { link = "markdownH5Delimiter" },
-		["@text.title.6.markdown"] = { link = "markdownH6" },
-		["@text.title.6.marker.markdown"] = { link = "markdownH6Delimiter" },
-		["@text.underline"] = { underline = true },
-		["@text.uri"] = { fg = groups.link },
-		["@text.warning"] = { fg = groups.warn },
-		["@todo"] = { link = "Todo" },
-		["@type"] = { link = "Type" },
-		["@variable"] = { fg = palette.text, italic = styles.italic },
-		["@variable.builtin"] = { fg = palette.love },
 
+		--- Plugins
 		-- romgrk/barbar.nvim
 		BufferCurrent = { fg = palette.text, bg = palette.overlay },
 		BufferCurrentIndex = { fg = palette.text, bg = palette.overlay },
@@ -378,11 +486,6 @@ local function set_highlights()
 		IblIndent = { fg = palette.overlay },
 		IblScope = { fg = palette.foam },
 		IblWhitespace = { fg = palette.overlay },
-
-		-- for legacy usage
-		IndentBlanklineChar = { fg = palette.muted, nocombine = true },
-		IndentBlanklineSpaceChar = { fg = palette.muted, nocombine = true },
-		IndentBlanklineSpaceCharBlankline = { fg = palette.muted, nocombine = true },
 
 		-- hrsh7th/nvim-cmp
 		CmpItemAbbr = { fg = palette.subtle },
@@ -608,7 +711,6 @@ local function set_highlights()
 		-- github/copilot.vim
 		CopilotSuggestion = { fg = palette.muted, italic = styles.italic },
 	}
-
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },
 		DiagnosticVirtualTextHint = { fg = groups.hint },
@@ -628,6 +730,9 @@ local function set_highlights()
 		TabLineFill = { bg = "NONE" },
 		TabLineSel = { fg = palette.text, bg = "NONE", bold = styles.bold },
 
+		-- ["@markup.raw"] = { bg = "none" },
+		-- ["@markup.raw.block"] = { bg = "none" },
+
 		TelescopeNormal = { fg = palette.subtle, bg = "NONE" },
 		TelescopePromptNormal = { fg = palette.text, bg = "NONE" },
 		TelescopeSelection = { fg = palette.text, bg = "NONE", bold = styles.bold },
@@ -645,31 +750,41 @@ local function set_highlights()
 		MiniPickPrompt = { bg = "NONE", bold = styles.bold },
 	}
 
+	if config.options.enable.legacy_highlights then
+		for group, highlight in pairs(legacy_highlights) do
+			highlights[group] = highlight
+		end
+	end
+	for group, highlight in pairs(default_highlights) do
+		highlights[group] = highlight
+	end
 	if styles.transparency then
 		for group, highlight in pairs(transparency_highlights) do
 			highlights[group] = highlight
 		end
 	end
+	if config.options.highlight_groups ~= nil and next(config.options.highlight_groups) ~= nil then
+		vim.print(config.options.highlight_groups)
+		for group, options in pairs(config.options.highlight_groups) do
+			local default_opts = highlights[group] or {}
 
-	for group, options in pairs(config.options.highlight_groups) do
-		local default_opts = highlights[group] or {}
+			if (options.inherit == nil or options.inherit) and default_opts ~= nil then
+				options.inherit = nil
+				highlights[group] = vim.tbl_extend("force", default_opts, options)
+			else
+				options.inherit = nil
+				highlights[group] = options
+			end
 
-		if (options.inherit == nil or options.inherit) and default_opts ~= nil then -- On merge.
-			options.inherit = nil -- Don't add this key to the highlight_group after merge.
-			highlights[group] = vim.tbl_extend("force", default_opts, options)
-		else -- On overwrite.
-			options.inherit = nil -- Don't add this key to the highlight_group.
-			highlights[group] = options
+			highlights[group] = vim.tbl_extend("force", highlights[group] or {}, options)
 		end
-
-		highlights[group] = vim.tbl_extend("force", highlights[group] or {}, options)
 	end
-
 	for group, highlight in pairs(highlights) do
 		config.options.before_highlight(group, highlight, palette)
 		utilities.highlight(group, highlight)
 	end
 
+	--- Terminal
 	if config.options.enable.terminal then
 		vim.g.terminal_color_0 = palette.overlay -- black
 		vim.g.terminal_color_8 = palette.subtle -- bright black

--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -20,9 +20,6 @@ local function set_highlights()
 		}
 	end
 
-	local adaptive_title = { fg = styles.bold and palette.text or palette.foam, bold = styles.bold }
-	local adaptive_border = make_border()
-
 	local highlights = {}
 	local legacy_highlights = {
 		["@attribute.diff"] = { fg = palette.gold },
@@ -98,10 +95,10 @@ local function set_highlights()
 		diffAdded = { link = "DiffAdd" },
 		diffChanged = { link = "DiffChange" },
 		diffRemoved = { link = "DiffDelete" },
-		Directory = adaptive_title,
+		Directory = { fg = palette.foam, bold = styles.bold },
 		-- EndOfBuffer = {},
 		ErrorMsg = { fg = groups.error, bold = styles.bold },
-		FloatBorder = adaptive_border,
+		FloatBorder = make_border(),
 		FloatTitle = { link = "Directory" },
 		FoldColumn = { fg = palette.muted },
 		Folded = { fg = palette.text, bg = groups.panel },
@@ -144,7 +141,7 @@ local function set_highlights()
 		TabLine = { fg = palette.subtle, bg = groups.panel },
 		TabLineFill = { bg = groups.panel },
 		TabLineSel = { fg = palette.text, bg = palette.overlay, bold = styles.bold },
-		Title = adaptive_title,
+		Title = { fg = palette.foam, bold = styles.bold },
 		VertSplit = { fg = groups.border },
 		Visual = { bg = palette.highlight_med },
 		-- VisualNOS = {},
@@ -357,7 +354,7 @@ local function set_highlights()
 		["@markup.strikethrough"] = { strikethrough = true },
 		["@markup.underline"] = { underline = true },
 
-		["@markup.heading"] = adaptive_title,
+		["@markup.heading"] = { fg = palette.foam, bold = styles.bold },
 
 		["@markup.quote"] = { fg = palette.subtle },
 		["@markup.math"] = { link = "Special" },
@@ -459,7 +456,7 @@ local function set_highlights()
 		NvimTreeNormal = { link = "Normal" },
 		NvimTreeOpenedFile = { fg = palette.text, bg = palette.overlay },
 		NvimTreeOpenedFolderName = { link = "NvimTreeFolderName" },
-		NvimTreeRootFolder = adaptive_title,
+		NvimTreeRootFolder = { fg = palette.foam, bold = styles.bold },
 		NvimTreeSpecialFile = { link = "NvimTreeNormal" },
 		NvimTreeWindowPicker = { link = "StatusLineTerm" },
 
@@ -545,22 +542,22 @@ local function set_highlights()
 		NeorgHeading5Title = { link = "markdownH5" },
 		NeorgHeading6Prefix = { link = "markdownH6Delimiter" },
 		NeorgHeading6Title = { link = "markdownH6" },
-		NeorgMarkerTitle = adaptive_title,
+		NeorgMarkerTitle = { fg = palette.foam, bold = styles.bold },
 
 		-- tami5/lspsaga.nvim (fork of glepnir/lspsaga.nvim)
 		DefinitionCount = { fg = palette.rose },
 		DefinitionIcon = { fg = palette.rose },
 		DefintionPreviewTitle = { fg = palette.rose, bold = styles.bold },
-		LspFloatWinBorder = adaptive_border,
+		LspFloatWinBorder = make_border(),
 		LspFloatWinNormal = { bg = groups.panel },
 		LspSagaAutoPreview = { fg = palette.subtle },
 		LspSagaCodeActionBorder = make_border(palette.rose),
 		LspSagaCodeActionContent = { fg = palette.foam },
 		LspSagaCodeActionTitle = { fg = palette.gold, bold = styles.bold },
 		LspSagaCodeActionTruncateLine = { link = "LspSagaCodeActionBorder" },
-		LspSagaDefPreviewBorder = adaptive_border,
+		LspSagaDefPreviewBorder = make_border(),
 		LspSagaDiagnosticBorder = make_border(palette.gold),
-		LspSagaDiagnosticHeader = adaptive_title,
+		LspSagaDiagnosticHeader = { fg = palette.foam, bold = styles.bold },
 		LspSagaDiagnosticTruncateLine = { link = "LspSagaDiagnosticBorder" },
 		LspSagaDocTruncateLine = { link = "LspSagaHoverBorder" },
 		LspSagaFinderSelection = { fg = palette.gold },
@@ -597,26 +594,26 @@ local function set_highlights()
 		HopUnmatched = { fg = palette.muted },
 
 		-- nvim-telescope/telescope.nvim
-		TelescopeBorder = adaptive_border,
+		TelescopeBorder = make_border(),
 		TelescopeMatching = { fg = palette.rose },
 		TelescopeNormal = { link = "NormalFloat" },
 		TelescopePromptNormal = { link = "TelescopeNormal" },
 		TelescopePromptPrefix = { fg = palette.subtle },
 		TelescopeSelection = { fg = palette.text, bg = palette.overlay },
 		TelescopeSelectionCaret = { fg = palette.rose, bg = palette.overlay },
-		TelescopeTitle = adaptive_title,
+		TelescopeTitle = { fg = palette.foam, bold = styles.bold },
 
 		-- ibhagwan/fzf-lua
 		FzfLuaNormal = { link = "NormalFloat" },
-		FwzfLuaTitle = adaptive_title,
-		FzfLuaBorder = adaptive_border,
+		FwzfLuaTitle = { fg = palette.foam, bold = styles.bold },
+		FzfLuaBorder = make_border(),
 		FzfLuaHeaderText = { fg = palette.love },
 		FzfLuaHeaderBind = { fg = palette.rose },
 		FzfLuaBufFlagCur = { fg = palette.subtle },
 		FzfLuaBufFlagAlt = { fg = palette.subtle },
 
 		-- rcarriga/nvim-notify
-		NotifyDEBUGBorder = adaptive_border,
+		NotifyDEBUGBorder = make_border(),
 		NotifyDEBUGIcon = { link = "NotifyDEBUGTitle" },
 		NotifyDEBUGTitle = { fg = palette.muted },
 		NotifyERRORBorder = make_border(groups.error),
@@ -639,7 +636,7 @@ local function set_highlights()
 		DapUIBreakpointsLine = { link = "DapUIBreakpointsPath" },
 		DapUIBreakpointsPath = { fg = palette.foam },
 		DapUIDecoration = { link = "DapUIBreakpointsPath" },
-		DapUIFloatBorder = adaptive_border,
+		DapUIFloatBorder = make_border(),
 		DapUIFrameName = { fg = palette.text },
 		DapUILineNumber = { link = "DapUIBreakpointsPath" },
 		DapUIModifiedValue = { fg = palette.foam, bold = styles.bold },

--- a/lua/rose-pine/config.lua
+++ b/lua/rose-pine/config.lua
@@ -1,7 +1,7 @@
 ---@alias Variant "main" | "moon" | "dawn"
 ---@alias Palette { base: string, surface: string, overlay: string, muted: string, subtle: string, text: string, love: string, gold: string, rose: string, pine: string, foam: string, iris: string }
 ---@alias PaletteColor "base" | "surface" | "overlay" | "muted" | "subtle" | "text" | "love" | "gold" | "rose" | "pine" | "foam" | "iris" | "highlight_low" | "highlight_med" | "highlight_high"
----@alias Highlight { fg: string, bg: string, sp: string, bold: boolean, italic: boolean, undercurl: boolean, underline: boolean, underdouble: boolean, underdotted: boolean, underdashed: boolean, strikethrough: boolean }
+---@alias Highlight { fg: string, bg: string, sp: string, bold: boolean, italic: boolean, undercurl: boolean, underline: boolean, underdouble: boolean, underdotted: boolean, underdashed: boolean, strikethrough: boolean, inherit: boolean }
 
 local config = {}
 
@@ -24,8 +24,9 @@ config.options = {
 	extend_background_behind_borders = true,
 
 	enable = {
-		terminal = true,
+		legacy_highlights = true,
 		migrations = true,
+		terminal = true,
 	},
 
 	styles = {
@@ -43,6 +44,8 @@ config.options = {
 		error = "love",
 		hint = "iris",
 		info = "foam",
+		note = "pine",
+		todo = "rose",
 		warn = "gold",
 
 		git_add = "foam",
@@ -56,7 +59,7 @@ config.options = {
 		git_text = "rose",
 		git_untracked = "subtle",
 
-		---@type string | PaletteColor | table<string, string | PaletteColor>
+		---@type table<string, string | PaletteColor>
 		headings = {
 			h1 = "iris",
 			h2 = "foam",
@@ -72,6 +75,8 @@ config.options = {
 		-- comment = "subtle",
 		---@deprecated Replaced by `options.highlight_groups["@punctuation"]`
 		-- punctuation = "muted",
+		---@deprecated Expects a table with values h1...h6
+		-- headings = "text",
 	},
 
 	---@type table<string, Highlight>
@@ -103,6 +108,10 @@ local function migrate(options)
 		options.highlight_groups["WinSeparator"] = { fg = border, bg = border }
 	end
 
+	if options.disable_background then
+		options.highlight_groups["Normal"] = { bg = "NONE" }
+	end
+
 	if options.disable_float_background then
 		options.highlight_groups["NormalFloat"] = { bg = "NONE" }
 	end
@@ -121,7 +130,8 @@ local function migrate(options)
 		options.highlight_groups["@punctuation"] = { fg = options.groups.punctuation }
 	end
 
-	options.styles.transparency = options.disable_background or options.styles.transparency
+	options.styles.transparency = (options.disable_background and options.disable_float_background)
+		or options.styles.transparency
 
 	-- These never actually existed, but may be set intuitively by the user
 	-- because of `disable_italics` existing.

--- a/lua/rose-pine/config.lua
+++ b/lua/rose-pine/config.lua
@@ -59,15 +59,13 @@ config.options = {
 		git_text = "rose",
 		git_untracked = "subtle",
 
-		---@type table<string, string | PaletteColor>
-		headings = {
-			h1 = "iris",
-			h2 = "foam",
-			h3 = "rose",
-			h4 = "gold",
-			h5 = "pine",
-			h6 = "foam",
-		},
+		---@type string | PaletteColor
+		h1 = "iris",
+		h2 = "foam",
+		h3 = "rose",
+		h4 = "gold",
+		h5 = "pine",
+		h6 = "foam",
 
 		---@deprecated Replaced by `options.highlight_groups["Normal"]`
 		-- background = "base",
@@ -151,6 +149,14 @@ local function migrate(options)
 			h5 = options.groups.headings,
 			h6 = options.groups.headings,
 		}
+	end
+	if type(options.groups.headings) == "table" then
+		options.groups.h1 = options.groups.headings.h1 or options.groups.h1
+		options.groups.h2 = options.groups.headings.h2 or options.groups.h2
+		options.groups.h3 = options.groups.headings.h3 or options.groups.h3
+		options.groups.h4 = options.groups.headings.h4 or options.groups.h4
+		options.groups.h5 = options.groups.headings.h5 or options.groups.h5
+		options.groups.h6 = options.groups.headings.h6 or options.groups.h6
 	end
 
 	return options

--- a/lua/rose-pine/utilities.lua
+++ b/lua/rose-pine/utilities.lua
@@ -58,7 +58,6 @@ function utilities.highlight(group, highlight, blend_on)
 	highlight.fg = fg
 	highlight.bg = bg
 	highlight.sp = sp
-	-- highlight = vim.tbl_extend("force", highlight, { fg = fg, bg = bg, sp = sp })
 
 	vim.api.nvim_set_hl(0, group, highlight)
 end

--- a/lua/rose-pine/utilities.lua
+++ b/lua/rose-pine/utilities.lua
@@ -15,9 +15,9 @@ local function color_to_rgb(color)
 end
 
 ---@param color string Palette key or hex value
-local function parse_color(color)
+function utilities.parse_color(color)
 	if color == nil then
-		return print("Invalid color")
+		return print("Invalid color: " .. color)
 	end
 
 	color = color:lower()
@@ -32,7 +32,7 @@ end
 ---@param fg string Foreground color
 ---@param bg string Background color
 ---@param alpha number Between 0 (background) and 1 (foreground)
-local function blend(fg, bg, alpha)
+function utilities.blend(fg, bg, alpha)
 	local fg_rgb = color_to_rgb(fg)
 	local bg_rgb = color_to_rgb(bg)
 
@@ -42,24 +42,6 @@ local function blend(fg, bg, alpha)
 	end
 
 	return string.format("#%02X%02X%02X", blend_channel(1), blend_channel(2), blend_channel(3))
-end
-
----@param group string
----@param highlight table<string, any>
-function utilities.highlight(group, highlight, blend_on)
-	local fg = highlight.fg and parse_color(highlight.fg) or "NONE"
-	local bg = highlight.bg and parse_color(highlight.bg) or "NONE"
-	local sp = highlight.sp and parse_color(highlight.sp) or "NONE"
-
-	if highlight.blend ~= nil and (highlight.blend >= 0 and highlight.blend <= 100) and bg ~= nil then
-		bg = blend(bg, blend_on or require("rose-pine.palette").base, highlight.blend / 100)
-	end
-
-	highlight.fg = fg
-	highlight.bg = bg
-	highlight.sp = sp
-
-	vim.api.nvim_set_hl(0, group, highlight)
 end
 
 return utilities

--- a/readme.md
+++ b/readme.md
@@ -94,14 +94,12 @@ require('rose-pine').setup({
         git_text = "rose",
         git_untracked = "subtle",
 
-        headings = {
-            h1 = "iris",
-            h2 = "foam",
-            h3 = "rose",
-            h4 = "gold",
-            h5 = "pine",
-            h6 = "foam",
-        },
+        h1 = "iris",
+        h2 = "foam",
+        h3 = "rose",
+        h4 = "gold",
+        h5 = "pine",
+        h6 = "foam",
     },
 
     highlight_groups = {

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,14 @@ require('rose-pine').setup({
     dim_inactive_windows = false,
     extend_background_behind_borders = true,
 
+    enable = {
+        terminal = true,
+        -- Improve compatibility for previous versions of Neovim
+        legacy_highlights = true,
+	-- Handle deprecated options automatically
+        migrations = true,
+    },
+
     styles = {
         bold = true,
         italic = true,
@@ -71,6 +79,8 @@ require('rose-pine').setup({
         error = "love",
         hint = "iris",
         info = "foam",
+        note = "pine",
+        todo = "rose",
         warn = "gold",
 
         git_add = "foam",
@@ -92,8 +102,6 @@ require('rose-pine').setup({
             h5 = "pine",
             h6 = "foam",
         },
-        -- Alternatively, set all headings at once.
-        -- headings = "subtle",
     },
 
     highlight_groups = {
@@ -125,6 +133,6 @@ vim.cmd('colorscheme rose-pine')
 
 ## Contributing
 
-We welcome and appreciate contributions of any kind. Create an issue or start a discussion for any proposed changes. Pull requests are encouraged for supporting additional plugins.
+We welcome and appreciate contributions of any kind. Create an issue or start a discussion for any proposed changes. Pull requests are encouraged for supporting additional plugins or [treesitter improvements](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#highlights).
 
 Feel free to update the [wiki](https://github.com/rose-pine/neovim/wiki/) with any [recipes](https://github.com/rose-pine/neovim/wiki/Recipes).


### PR DESCRIPTION
This PR adds new treesitter groups, ref https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1900679583

_Feedback is welcome_

## New options

```diff
{
  enable = {
+    legacy_highlights = true
  },
  groups = {
+    note = "pine",
+    todo = "rose",
  }
}
```

We may take this opportunity to refactor a lil, breaking out treesitter and plugin highlights into separate files.

Ref #216, #218