### PR TITLE
feat: Add support for Neotest

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -460,6 +460,26 @@ local function set_highlights()
 		NvimTreeSpecialFile = { link = "NvimTreeNormal" },
 		NvimTreeWindowPicker = { link = "StatusLineTerm" },
 
+		-- nvim-neotest/neotest
+		NeotestAdapterName = { fg = palette.iris },
+		NeotestBorder = { fg = palette.highlight_med },
+		NeotestDir = { fg = palette.foam },
+		NeotestExpandMarker = { fg = palette.highlight_med },
+		NeotestFailed = { fg = palette.love },
+		NeotestFile = { fg = palette.text },
+		NeotestFocused = { fg = palette.gold, bg = palette.highlight_med },
+		NeotestIndent = { fg = "" },
+		NeotestMarked = { fg = palette.rose, bold = styles.bold },
+		NeotestNamespace = { fg = palette.gold },
+		NeotestPassed = { fg = palette.pine },
+		NeotestRunning = { fg = palette.gold },
+		NeotestWinSelect = { fg = palette.muted },
+		NeotestSkipped = { fg = palette.subtle },
+		NeotestTarget = { fg = palette.love },
+		NeotestTest = { fg = palette.gold },
+		NeotestUnknown = { fg = palette.subtle },
+		NeotestWatching = { fg = palette.iris },
+
 		-- nvim-neo-tree/neo-tree.nvim
 		NeoTreeGitAdded = { fg = groups.git_add },
 		NeoTreeGitConflict = { fg = groups.git_merge },


### PR DESCRIPTION
https://github.com/nvim-neotest/neotest/

:wave: I'm switching to the Neotest runner and instead of adding theme support to my own set up I figured I'd add it to the plugin directly. I matched the colors roughly to those used by default in the plugin. I'd appreciate any suggestions to make the color selections better align with the intentions of the theme and anything else needed to merge (e.g., do I need add to the `transparency_highlights` list as well?). Thanks!