### PR TITLE
fix: use treesitter highlights for @lsp.type.variable

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -395,7 +395,7 @@ local function set_highlights()
 		["@lsp.type.namespace"] = { link = "@namespace" },
 		["@lsp.type.parameter"] = { link = "@parameter" },
 		["@lsp.type.property"] = { link = "@property" },
-		["@lsp.type.variable"] = { link = "@variable" },
+		["@lsp.type.variable"] = {}, -- use treesitter styles for regular variables
 		["@lsp.typemod.function.defaultLibrary"] = { link = "@function.builtin" },
 		["@lsp.typemod.operator.injected"] = { link = "@operator" },
 		["@lsp.typemod.string.injected"] = { link = "@string" },


### PR DESCRIPTION
fixes #227 