### PR TITLE
feat: prioritise semantic variable highlighting

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -412,7 +412,7 @@ local function set_highlights()
 		["@lsp.type.namespace"] = { link = "@namespace" },
 		["@lsp.type.parameter"] = { link = "@parameter" },
 		["@lsp.type.property"] = { link = "@property" },
-		["@lsp.type.variable"] = {}, -- use treesitter styles for regular variables
+		["@lsp.type.variable"] = { link = "@variable" },
 		["@lsp.typemod.function.defaultLibrary"] = { link = "@function.builtin" },
 		["@lsp.typemod.operator.injected"] = { link = "@operator" },
 		["@lsp.typemod.string.injected"] = { link = "@string" },


### PR DESCRIPTION
This commit prioritises semantic variables over treesitter—useful in cases such as Svelte strings with variables:

```svelte
<Card title="Welcome back, {username}" />
```

Previously `{username}` would have been highlighted as a string. Now, it is highlighted as a variable.