### PR TITLE
feat: add highlight groups for folke/trouble.nvim

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -727,6 +727,11 @@ local function set_highlights()
 		-- folke/noice.nvim
 		NoiceCursor = { fg = palette.highlight_high, bg = palette.text },
 
+		-- folke/trouble.nvim
+		TroubleText = { fg = palette.subtle },
+		TroubleCount = { fg = palette.iris, bg = palette.surface },
+		TroubleNormal = { fg = palette.text, bg = groups.panel },
+
 		-- echasnovski/mini.clue
 		MiniClueTitle = { bg = groups.panel, bold = styles.bold },
 


### PR DESCRIPTION
Adds [highlight groups](https://github.com/folke/tokyonight.nvim/blob/610179f7f12db3d08540b6cc61434db2eaecbcff/lua/tokyonight/theme.lua#L397) for [folke/trouble.nvim](https://github.com/folke/trouble.nvim). Trying to mimic the colors laid out in the first link to tokyonight theme, but it's a bit arbitrary. Let me know if you'd prefer some other colors.