### PR TITLE
feat: Add mini.statusline highlights

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -743,6 +743,18 @@ local function set_highlights()
 		MiniIndentscopeSymbol = { fg = palette.muted },
 		MiniIndentscopeSymbolOff = { fg = palette.muted },
 
+		-- echasnovski/mini.statusline
+		MiniStatuslineDevinfo = { fg = palette.subtle, bg = palette.overlay },
+		MiniStatuslineFileinfo = { link = "MiniStatuslineDevinfo" },
+		MiniStatuslineFilename = { fg = palette.muted, bg = palette.surface },
+		MiniStatuslineInactive = { link = "MiniStatuslineFilename" },
+		MiniStatuslineModeCommand = { fg = palette.base, bg = palette.love, bold = styles.bold },
+		MiniStatuslineModeInsert = { fg = palette.base, bg = palette.foam, bold = styles.bold },
+		MiniStatuslineModeNormal = { fg = palette.base, bg = palette.rose, bold = styles.bold },
+		MiniStatuslineModeOther = { fg = palette.base, bg = palette.rose, bold = styles.bold },
+		MiniStatuslineModeReplace = { fg = palette.base, bg = palette.pine, bold = styles.bold },
+		MiniStatuslineModeVisual = { fg = palette.base, bg = palette.iris, bold = styles.bold },
+
 		-- goolord/alpha-nvim
 		AlphaButtons = { fg = palette.foam },
 		AlphaFooter = { fg = palette.gold },


### PR DESCRIPTION
Adds highlights for [mini.statusline](https://github.com/echasnovski/mini.statusline). Let me know if other colors would would be preferable 

![image](https://github.com/rose-pine/neovim/assets/61782266/5ec4cbdb-5883-4d3b-b40a-1e07d489f9ee)

