### PR TITLE
fix: clear autocmd when loading other colorscheme

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -882,9 +882,13 @@ local function set_highlights()
 
 		-- Support StatusLineTerm & StatusLineTermNC from vim
 		vim.cmd([[
-		autocmd TermOpen * if &buftype=='terminal'
-			\|setlocal winhighlight=StatusLine:StatusLineTerm,StatusLineNC:StatusLineTermNC
-			\|else|setlocal winhighlight=|endif
+		augroup rose-pine
+			autocmd!
+			autocmd TermOpen * if &buftype=='terminal'
+				\|setlocal winhighlight=StatusLine:StatusLineTerm,StatusLineNC:StatusLineTermNC
+				\|else|setlocal winhighlight=|endif
+			autocmd ColorSchemePre * autocmd! rose-pine
+		augroup END
 		]])
 	end
 end


### PR DESCRIPTION
Problem: When switching the colorscheme from rose-pine to something else, the new colorshceme can be a bit off due to rose-pine's autocmd.

Solution: Clear the autocmd.

Ideally, it should also reset winhighlight for all windows it touched, but that requires a bit more work.