### PR TITLE
Add default highlights for nvim-treesitter-context

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -773,6 +773,10 @@ local function set_highlights()
 
 		-- github/copilot.vim
 		CopilotSuggestion = { fg = palette.muted, italic = styles.italic },
+
+		-- nvim-treesitter/nvim-treesitter-context
+		TreesitterContext = { bg = "overlay" },
+		TreesitterContextLineNumber = { fg = "rose", bg = "overlay" }
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },


### PR DESCRIPTION
This pull requests add support for the [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) plugin by adding some default highlighting.

The result will look like this:
![image](https://github.com/rose-pine/neovim/assets/22551563/231b67c8-5c2f-41d0-9135-6de2a49db2b5)
