### PR TITLE
Fix issue where palette value wasn't being referenced correctly

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -775,8 +775,8 @@ local function set_highlights()
 		CopilotSuggestion = { fg = palette.muted, italic = styles.italic },
 
 		-- nvim-treesitter/nvim-treesitter-context
-		TreesitterContext = { bg = "overlay" },
-		TreesitterContextLineNumber = { fg = "rose", bg = "overlay" }
+		TreesitterContext = { bg = palette.overlay },
+		TreesitterContextLineNumber = { fg = palette.rose, bg = palette.overlay }
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },


### PR DESCRIPTION
After updating to ea0d8dbc8e126d38cbc12c8ed0ee6deec4e95dbf I started seeing this error:
```
   Error  10:00:18 PM notify.error lazy.nvim Failed to run `config` for rose-pine

vim/_editor.lua:0: /home/dgreene/.config/nvim/init.lua..nvim_exec2() called at /home/dgreene/.config/nvim/init.lua:0../home/dgreene/.local/share/nvim/lazy/rose-pine/colors/rose-pine-moon.lua: Vim(colorscheme):E5113: Error while calling lua chunk: ...reene/.local/share/nvim/lazy/rose-pine/lua/rose-pine.lua:874: Invalid highlight color: 'overlay'
stack traceback:
	[C]: at 0x55ddd3901ae5
	...reene/.local/share/nvim/lazy/rose-pine/lua/rose-pine.lua:874: in function 'set_highlights'
	...reene/.local/share/nvim/lazy/rose-pine/lua/rose-pine.lua:920: in function 'colorscheme'
	...ocal/share/nvim/lazy/rose-pine/colors/rose-pine-moon.lua:2: in main chunk
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	/home/dgreene/.config/nvim/lua/plugins/theme.lua:16: in function 'config'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:366: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:364>
	[C]: in function 'xpcall'
	.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:113: in function 'try'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:381: in function 'config'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:348: in function '_load'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:123: in function 'startup'
	...reene/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:112: in function 'setup'
	/home/dgreene/.config/nvim/lua/config/lazy.lua:16: in main chunk
	[C]: in function 'require'
	/home/dgreene/.config/nvim/init.lua:2: in main chunk

# stacktrace:
  - vim/_editor.lua:0 _in_ **cmd**
  - lua/plugins/theme.lua:16 _in_ **config**
  - lua/config/lazy.lua:16
  - init.lua:2
```

This PR fixes the issue by switching to using the palette enum values vs the literal (`palette.rose` vs `"rose"`).