### PR TITLE
For transparency, remove BG for buffers and gray out the text

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -801,6 +801,7 @@ local function set_highlights()
 		SignColumn = { fg = palette.text, bg = "NONE" },
 		StatusLine = { fg = palette.subtle, bg = "NONE" },
 		StatusLineNC = { fg = palette.muted, bg = "NONE" },
+		TabLine = { bg = "NONE", fg = palette.subtle },
 		TabLineFill = { bg = "NONE" },
 		TabLineSel = { fg = palette.text, bg = "NONE", bold = styles.bold },
 


### PR DESCRIPTION
The transparency options don't currently set the TabLine. Here is a before & after:

<img width="688" alt="Screenshot 2024-04-17 at 21 32 57" src="https://github.com/rose-pine/neovim/assets/21108297/13a85a71-d12b-4405-89a7-178e1fa81065">
<img width="674" alt="Screenshot 2024-04-17 at 21 32 35" src="https://github.com/rose-pine/neovim/assets/21108297/758b2320-4c30-49b9-9d4c-d2c1961e7da2">
