### PR TITLE
Added ["@float"] to default_highlights (#272)

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -295,6 +295,7 @@ local function set_highlights()
 		["@boolean"] = { link = "Boolean" },
 		["@number"] = { link = "Number" },
 		["@number.float"] = { link = "Number" },
+		["@float"] = { link = "Number" },
 
 		--- Types
 		["@type"] = { fg = palette.foam },


### PR DESCRIPTION
The `@float`capture group is now linked to `Number`. Query files that use this capture group are now highlighted corrected when using treesitter.

__Before__:
![image](https://github.com/rose-pine/neovim/assets/82954751/82aad964-8252-4800-b7be-5129eccefa5e)

__After__:
![image](https://github.com/rose-pine/neovim/assets/82954751/2acc9cc7-ac64-4a95-a6dc-c5d602e1f250)
