### PR TITLE
Fix: link `@lsp.type.comment.c` and `@lsp.type.comment.cpp` to `@comment`

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -407,6 +407,8 @@ local function set_highlights()
 
 		--- Semantic
 		["@lsp.type.comment"] = {},
+		["@lsp.type.comment.c"] = { link = "@comment" },
+		["@lsp.type.comment.cpp"] = { link = "@comment" },
 		["@lsp.type.enum"] = { link = "@type" },
 		["@lsp.type.interface"] = { link = "@interface" },
 		["@lsp.type.keyword"] = { link = "@keyword" },


### PR DESCRIPTION
Fixes #281
![ifdef0301](https://github.com/rose-pine/neovim/assets/88616652/141f4e38-9ba9-4782-9b2b-8c09208ca3d6)