### PR TITLE
feat: add support for rainbow-delimiters.nvim

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -908,6 +908,15 @@ local function set_highlights()
 		IlluminatedWordRead = { link = "LspReferenceRead" },
 		IlluminatedWordText = { link = "LspReferenceText" },
 		IlluminatedWordWrite = { link = "LspReferenceWrite" },
+
+		-- HiPhish/rainbow-delimiters.nvim
+		RainbowDelimiterBlue = { fg = palette.pine },
+		RainbowDelimiterCyan = { fg = palette.foam },
+		RainbowDelimiterGreen = { fg = palette.leaf },
+		RainbowDelimiterOrange = { fg = palette.rose },
+		RainbowDelimiterRed = { fg = palette.love },
+		RainbowDelimiterViolet = { fg = palette.iris },
+		RainbowDelimiterYellow = { fg = palette.gold },
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },


### PR DESCRIPTION
Add support for [rainbow-delimiters.nvim](https://github.com/HiPhish/rainbow-delimiters.nvim) for colorful matching brackets, parenthesis, braces.

Example of plugin in action:

![2024-07-21_17-31](https://github.com/user-attachments/assets/da162d6c-b391-4383-a95d-c2e2078fa497)
