### PR TITLE
fix: add missing highlight for `NeotestIndent`

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -498,7 +498,7 @@ local function set_highlights()
 		NeotestFailed = { fg = palette.love },
 		NeotestFile = { fg = palette.text },
 		NeotestFocused = { fg = palette.gold, bg = palette.highlight_med },
-		NeotestIndent = { fg = "" },
+		NeotestIndent = { fg = palette.highlight_med },
 		NeotestMarked = { fg = palette.rose, bold = styles.bold },
 		NeotestNamespace = { fg = palette.gold },
 		NeotestPassed = { fg = palette.pine },


### PR DESCRIPTION
The highlight for `NeotestIndent` was missing... and made the tree look very out of place IMO. 

This tree whether expanded or collapsed always shows `NeotestExpandMarker` which was already set to `highlight_med`, so having 2 different colors makes things look very off.

Before and after:

![neotest-before](https://github.com/user-attachments/assets/fd1a49ed-690d-4f07-a5ea-c0fea056fb86)
![neotest-after](https://github.com/user-attachments/assets/e8872cce-de32-4235-b54d-a96305889d47)
