### PR TITLE
fix: broken transparency for treesitter-context

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -954,6 +954,9 @@ local function set_highlights()
 		IblIndent = { fg = palette.overlay, bg = "NONE" },
 		IblScope = { fg = palette.foam, bg = "NONE" },
 		IblWhitespace = { fg = palette.overlay, bg = "NONE" },
+
+		TreesitterContext = { bg = "NONE" },
+		TreesitterContextLineNumber = { fg = palette.rose, bg = "NONE" },
 	}
 
 	if config.options.enable.legacy_highlights then


### PR DESCRIPTION
Fixes the broken transparency for treesitter-context background. These highlights were not added to `transparency_highlights` in the initial commit when support was first added.