### PR TITLE
feat: add support for grug-far.nvim

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -126,7 +126,7 @@ local function set_highlights()
 		RedrawDebugClear = { fg = palette.base, bg = palette.gold },
 		RedrawDebugComposed = { fg = palette.base, bg = palette.pine },
 		RedrawDebugRecompose = { fg = palette.base, bg = palette.love },
-		Search = { fg = palette.base, bg = palette.text },
+		Search = { fg = palette.base, bg = palette.rose },
 		SignColumn = { fg = palette.text, bg = "NONE" },
 		SpecialKey = { fg = palette.foam },
 		SpellBad = { sp = palette.subtle, undercurl = true },
@@ -941,6 +941,22 @@ local function set_highlights()
 		RenderMarkdownTableHead = { fg = palette.subtle },
 		RenderMarkdownTableRow = { fg = palette.subtle },
 		RenderMarkdownUnchecked = { fg = palette.subtle },
+
+		-- MagicDuck/grug-far.nvim
+		GrugFarHelpHeader = { fg = palette.pine },
+		GrugFarHelpHeaderKey = { fg = palette.gold },
+		GrugFarHelpWinActionKey = { fg = palette.gold },
+		GrugFarHelpWinActionPrefix = { fg = palette.foam },
+		GrugFarHelpWinActionText = { fg = palette.pine },
+		GrugFarHelpWinHeader = { link = "FloatTitle" },
+		GrugFarInputLabel = { fg = palette.foam },
+		GrugFarInputPlaceholder = { link = "Comment" },
+		GrugFarResultsActionMessage = { fg = palette.foam },
+		GrugFarResultsChangeIndicator = { fg = groups.git_change },
+		GrugFarResultsHeader = { fg = palette.pine },
+		GrugFarResultsMatch = { link = "Search" },
+		GrugFarResultsPath = { fg = palette.foam },
+		GrugFarResultsStats = { fg = palette.iris },
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },

--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -954,7 +954,7 @@ local function set_highlights()
 		GrugFarResultsActionMessage = { fg = palette.foam },
 		GrugFarResultsChangeIndicator = { fg = groups.git_change },
 		GrugFarResultsHeader = { fg = palette.pine },
-		GrugFarResultsMatch = { link = "Search" },
+		GrugFarResultsMatch = { link = "CurSearch" },
 		GrugFarResultsPath = { fg = palette.foam },
 		GrugFarResultsStats = { fg = palette.iris },
 	}

--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -954,6 +954,8 @@ local function set_highlights()
 		GrugFarResultsActionMessage = { fg = palette.foam },
 		GrugFarResultsChangeIndicator = { fg = groups.git_change },
 		GrugFarResultsHeader = { fg = palette.pine },
+		GrugFarResultsLineNo = { fg = palette.iris },
+		GrugFarResultsLineColumn = { link = "GrugFarResultsLineNo" },
 		GrugFarResultsMatch = { link = "CurSearch" },
 		GrugFarResultsPath = { fg = palette.foam },
 		GrugFarResultsStats = { fg = palette.iris },


### PR DESCRIPTION
Add support for [grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim) - a new super simple find and replace plugin powered by ripgrep.

![2024-07-25_00-45](https://github.com/user-attachments/assets/7a8dff23-2569-4dcb-a95a-458c39350a1b)
