### PR TITLE
chore: update highlights for dashboard-nvim

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -720,10 +720,18 @@ local function set_highlights()
 		DapUIWatchesValue = { link = "DapUIThread" },
 
 		-- glepnir/dashboard-nvim
-		DashboardCenter = { fg = palette.gold },
-		DashboardFooter = { fg = palette.iris },
+		DashboardDesc = { fg = palette.foam },
+		DashboardFiles = { fg = palette.iris },
+		DashboardFooter = { fg = palette.iris, italic = styles.italic },
 		DashboardHeader = { fg = palette.pine },
-		DashboardShortcut = { fg = palette.love },
+		DashboardIcon = { fg = palette.rose },
+		DashboardKey = { fg = palette.gold },
+		DashboardMruIcon = { fg = palette.foam },
+		DashboardMruTitle = { fg = palette.foam },
+		DashboardProjectIcon = { link = "DashboardIcon" },
+		DashboardProjectTitle = { fg = palette.foam },
+		DashboardShortcut = { fg = palette.gold },
+		DashboardShortcutIcon = { link = "DashboardIcon" },
 
 		-- SmiteshP/nvim-navic
 		NavicIconsArray = { fg = palette.gold },


### PR DESCRIPTION
Remove deprecated hl group `DashboardCenter` and fully support [dashboard-nvim](https://github.com/nvimdev/dashboard-nvim)

Before:

![2024-07-26_08-52](https://github.com/user-attachments/assets/6d482b33-241d-4647-9a79-33b9b243e015)

After:

![2024-07-26_08-59](https://github.com/user-attachments/assets/1da26cd4-e40c-4f93-9d70-d2fcd80225c5)
