### PR TITLE
feat: palette overrides

### DIFF
--- a/lua/rose-pine/config.lua
+++ b/lua/rose-pine/config.lua
@@ -35,6 +35,9 @@ config.options = {
 		transparency = false,
 	},
 
+	---@type table<string, table<string, string>>
+	palette = {},
+
 	---@type table<string, string | PaletteColor>
 	groups = {
 		border = "muted",

--- a/lua/rose-pine/palette.lua
+++ b/lua/rose-pine/palette.lua
@@ -62,6 +62,28 @@ local variants = {
 	},
 }
 
+if options.palette ~= nil and next(options.palette) then
+	-- handle override of all variants if defined in config
+	if options.palette["all"] then
+		for variant_name in pairs(variants) do
+			variants[variant_name] = vim.tbl_extend("force", variants[variant_name], options.palette["all"])
+		end
+	end
+
+	-- handle variant specific overrides
+	for variant_name, override_palette in pairs(options.palette) do
+		-- ignore pseudo variant all as is was allready handeld
+		if variant_name == "all" then
+			goto continue
+		end
+
+		if variants[variant_name] then
+			variants[variant_name] = vim.tbl_extend("force", variants[variant_name], override_palette or {})
+		end
+		::continue::
+	end
+end
+
 if variants[options.variant] ~= nil then
 	return variants[options.variant]
 end

--- a/lua/rose-pine/palette.lua
+++ b/lua/rose-pine/palette.lua
@@ -63,13 +63,6 @@ local variants = {
 }
 
 if options.palette ~= nil and next(options.palette) then
-	-- handle override of all variants if defined in config
-	if options.palette["all"] then
-		for variant_name in pairs(variants) do
-			variants[variant_name] = vim.tbl_extend("force", variants[variant_name], options.palette["all"])
-		end
-	end
-
 	-- handle variant specific overrides
 	for variant_name, override_palette in pairs(options.palette) do
 		-- ignore pseudo variant all as is was allready handeld

--- a/lua/rose-pine/palette.lua
+++ b/lua/rose-pine/palette.lua
@@ -65,15 +65,9 @@ local variants = {
 if options.palette ~= nil and next(options.palette) then
 	-- handle variant specific overrides
 	for variant_name, override_palette in pairs(options.palette) do
-		-- ignore pseudo variant all as is was allready handeld
-		if variant_name == "all" then
-			goto continue
-		end
-
 		if variants[variant_name] then
 			variants[variant_name] = vim.tbl_extend("force", variants[variant_name], override_palette or {})
 		end
-		::continue::
 	end
 end
 

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,16 @@ require("rose-pine").setup({
         h6 = "foam",
     },
 
+    pallet = {
+        -- override (or append) default color palette of specified variants
+        -- moon = {
+        --     base = '#18191a',
+        --     overlay = '#363738',
+        -- },
+	--
+	-- use "all" instead of variant name to override colors in all variants
+    },
+
     highlight_groups = {
         -- Comment = { fg = "foam" },
         -- VertSplit = { fg = "muted", bg = "muted" },

--- a/readme.md
+++ b/readme.md
@@ -100,8 +100,8 @@ require("rose-pine").setup({
         h6 = "foam",
     },
 
-    pallet = {
-        -- override (or append) default color palette of specified variants
+    pallete = {
+        -- Override the builtin palette per variant
         -- moon = {
         --     base = '#18191a',
         --     overlay = '#363738',

--- a/readme.md
+++ b/readme.md
@@ -106,8 +106,6 @@ require("rose-pine").setup({
         --     base = '#18191a',
         --     overlay = '#363738',
         -- },
-	--
-	-- use "all" instead of variant name to override colors in all variants
     },
 
     highlight_groups = {


### PR DESCRIPTION
Should partially implement #276 (if i read it correctly).

Allows users to override the default color palette without `before_highlight` using a new config option
`palette`.  This does not allow the addition of new variants, only the modification of existing ones, but this implementation could easily be extended to support the addition of new palette variants.


Proposed functionality:
``` lua
    pallet = {
        -- override (or append) default color palette of specified variants
        -- moon = {
        --     base = '#18191a',
        --     overlay = '#363738',
        -- },
    },
```

Edit: removed all option