### PR TITLE
Update rose-pine.lua

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -697,7 +697,7 @@ local function set_highlights()
 		NotifyWARNBorder = make_border(groups.warn),
 		NotifyWARNIcon = { link = "NotifyWARNTitle" },
 		NotifyWARNTitle = { fg = groups.warn },
-
+		NotifyBackground = { bg = palette.surface },
 		-- rcarriga/nvim-dap-ui
 		DapUIBreakpointsCurrentLine = { fg = palette.gold, bold = styles.bold },
 		DapUIBreakpointsDisabledLine = { fg = palette.muted },


### PR DESCRIPTION
The nvim-notify `NotifyBackground` highlight is mapped to `Normal` (see [here](https://github.com/rcarriga/nvim-notify/blob/d333b6f167900f6d9d42a59005d82919830626bf/lua/notify/config/highlights.lua#L5)). However, the `Normal.bg` is explicitly set to `"NONE"` in rose-pine which triggers an annoying nvim-notify warning the first time a notification fires in each nvim session.