### PR TITLE
chore: markdown.nvim renamed to render-markdown.nvim

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -924,7 +924,7 @@ local function set_highlights()
 		RainbowDelimiterViolet = { fg = palette.iris },
 		RainbowDelimiterYellow = { fg = palette.gold },
 
-		-- MeanderingProgrammer/markdown.nvim
+		-- MeanderingProgrammer/render-markdown.nvim
 		RenderMarkdownBullet = { fg = palette.rose },
 		RenderMarkdownChecked = { fg = palette.foam },
 		RenderMarkdownCode = { bg = palette.overlay },


### PR DESCRIPTION
Reference to change: https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/aeb5cec617c3bd5738ab82ba2c3f9ccdc27656c2