### PR TITLE
feat: add snacks indent highlights

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -683,23 +683,23 @@ local function set_highlights()
 
 		-- rcarriga/nvim-notify
 		NotifyBackground = { link = "NormalFloat" },
-		NotifyDEBUGBody = { link = 'NormalFloat' },
+		NotifyDEBUGBody = { link = "NormalFloat" },
 		NotifyDEBUGBorder = make_border(),
 		NotifyDEBUGIcon = { link = "NotifyDEBUGTitle" },
 		NotifyDEBUGTitle = { fg = palette.muted },
-		NotifyERRORBody = { link = 'NormalFloat' },
+		NotifyERRORBody = { link = "NormalFloat" },
 		NotifyERRORBorder = make_border(groups.error),
 		NotifyERRORIcon = { link = "NotifyERRORTitle" },
 		NotifyERRORTitle = { fg = groups.error },
-		NotifyINFOBody = { link = 'NormalFloat' },
+		NotifyINFOBody = { link = "NormalFloat" },
 		NotifyINFOBorder = make_border(groups.info),
 		NotifyINFOIcon = { link = "NotifyINFOTitle" },
 		NotifyINFOTitle = { fg = groups.info },
-		NotifyTRACEBody = { link = 'NormalFloat' },
+		NotifyTRACEBody = { link = "NormalFloat" },
 		NotifyTRACEBorder = make_border(palette.iris),
 		NotifyTRACEIcon = { link = "NotifyTRACETitle" },
 		NotifyTRACETitle = { fg = palette.iris },
-		NotifyWARNBody = { link = 'NormalFloat' },
+		NotifyWARNBody = { link = "NormalFloat" },
 		NotifyWARNBorder = make_border(groups.warn),
 		NotifyWARNIcon = { link = "NotifyWARNTitle" },
 		NotifyWARNTitle = { fg = groups.warn },
@@ -1013,6 +1013,12 @@ local function set_highlights()
 		BlinkCmpKindCopilot = { fg = palette.foam },
 		BlinkCmpKindSupermaven = { fg = palette.foam },
 		BlinkCmpKindTabNine = { fg = palette.foam },
+
+		-- folke/snacks.nvim
+		SnacksIndent = { fg = palette.overlay },
+		SnacksIndentChunk = { fg = palette.overlay },
+		SnacksIndentBlank = { fg = palette.overlay },
+		SnacksIndentScope = { fg = palette.foam },
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },


### PR DESCRIPTION
Added highlight support for folke/snacks.nvim indent module.
- Supports scope, blank, chunks and indent highlights
- Using same colors as lukas-reineke/indent-blankline.nvim

Below is a screenshot using my fork with the snacks indent plugin enabled

<img width="534" alt="Screenshot 2025-01-13 at 01 38 38" src="https://github.com/user-attachments/assets/ab8655dc-55e0-481e-8bf2-eba38b420ef0" />
