### PR TITLE
More obvious match highlight in snacks.picker

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -1019,6 +1019,8 @@ local function set_highlights()
 		SnacksIndentChunk = { fg = palette.overlay },
 		SnacksIndentBlank = { fg = palette.overlay },
 		SnacksIndentScope = { fg = palette.foam },
+
+		SnacksPickerMatch = { fg = palette.rose, bold = styles.bold },
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },


### PR DESCRIPTION
This uses the same color for match highlight as telescope

Before 
![2025-01-15-132809_grim](https://github.com/user-attachments/assets/4d4351b7-d3e7-4413-947c-628c397811d5)



After

![2025-01-15-132346_grim](https://github.com/user-attachments/assets/7a0789ad-4eb9-4825-83ad-c9afd653cfb8)
