### PR TITLE
refactor(gitsigns): avoid redundant links

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -451,9 +451,9 @@ local function set_highlights()
 		BufferVisibleTarget = { fg = palette.gold },
 
 		-- lewis6991/gitsigns.nvim
-		GitSignsAdd = { link = "SignAdd" },
-		GitSignsChange = { link = "SignChange" },
-		GitSignsDelete = { link = "SignDelete" },
+		GitSignsAdd = { fg = groups.git_add, bg = "NONE" },
+		GitSignsChange = { fg = groups.git_change, bg = "NONE" },
+		GitSignsDelete = { fg = groups.git_delete, bg = "NONE" },
 		SignAdd = { fg = groups.git_add, bg = "NONE" },
 		SignChange = { fg = groups.git_change, bg = "NONE" },
 		SignDelete = { fg = groups.git_delete, bg = "NONE" },


### PR DESCRIPTION
The `SignAdd`, `SignChange`, and `SignDelete` are never referenced by any other highlight definitions than the previous `GitSigns` ones before this change.

The isolated definitions are only left for backward compatibility.

This change would help [ex-colors.nvim](https://github.com/aileot/ex-colors.nvim) applied straightforwardly to rose-pine. (sorry for this shameless suggestion.)

