### PR TITLE
feat: add support for vim-sneak

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -1022,6 +1022,11 @@ local function set_highlights()
 		SnacksIndentScope = { fg = palette.foam },
 
 		SnacksPickerMatch = { fg = palette.rose, bold = styles.bold },
+
+		-- justinmk/vim-sneak
+		Sneak = { fg = palette.base, bg = palette.love },
+		SneakCurrent = { link = "StatusLineTerm" },
+		SneakScope = { link = "IncSearch" },
 	}
 	local transparency_highlights = {
 		DiagnosticVirtualTextError = { fg = groups.error },


### PR DESCRIPTION
Add support for the [vim-sneak](https://github.com/justinmk/vim-sneak) plugin. The highlight groups are detailed [here](https://github.com/justinmk/vim-sneak/blob/18b1faf020e6a66c1ce09b3ff5e6b6feb182973b/doc/sneak.txt#L349).

This is a preview of how the different highlight groups look like. I decided to base the coloring on the current [flash.nvim](https://github.com/rose-pine/neovim/blob/20c7940da844aa4f162a64e552ae3c7e9fdc3b93/lua/rose-pine.lua#L529) for the labels and matches, and [leap.nvim](https://github.com/rose-pine/neovim/blob/20c7940da844aa4f162a64e552ae3c7e9fdc3b93/lua/rose-pine.lua#L653) for the scope.

<img width="1710" alt="rosepine" src="https://github.com/user-attachments/assets/d2f8bb5f-f9b2-47ae-8e03-99bd7c52d92d" />
