### PR TITLE
Extends DapUIType foreground color to iris

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -722,6 +722,7 @@ local function set_highlights()
 		DapUIThread = { fg = palette.gold },
 		DapUIValue = { fg = palette.text },
 		DapUIVariable = { fg = palette.text },
+		DapUIType = { fg = palette.iris },
 		DapUIWatchesEmpty = { fg = palette.love },
 		DapUIWatchesError = { link = "DapUIWatchesEmpty" },
 		DapUIWatchesValue = { link = "DapUIThread" },


### PR DESCRIPTION
DapUIType uses purple fg atm, which can be changed to purple for consistent soho vibes. Let me know if it was an intentional choice not to override `DapUIType`:

https://github.com/rcarriga/nvim-dap-ui/blob/bc81f8d3440aede116f821114547a476b082b319/lua/dapui/config/highlights.lua#L20