### PR TITLE
fix(lualine): change bg_base from p.base to p.surface

### DIFF
--- a/lua/lualine/themes/rose-pine.lua
+++ b/lua/lualine/themes/rose-pine.lua
@@ -1,7 +1,7 @@
 local p = require("rose-pine.palette")
 local config = require("rose-pine.config")
 
-local bg_base = p.base
+local bg_base = p.surface
 if config.options.styles.transparency then
 	bg_base = "NONE"
 end


### PR DESCRIPTION
Using `p.base` leads to confusing and indistinguishable statuslines with horizontal splits.

Statuslines should use `p.surface`, according to https://rosepinetheme.com/palette/:

> Panels that are not directly related to the focal context --- cards, inputs, and **status lines**.

Statusline before:
![rose-pine-lualine](https://github.com/user-attachments/assets/a6720dee-c3a4-41cc-bf13-b0c7d6e29283)

Statusline after:
![rose-pine-lualine-fixed](https://github.com/user-attachments/assets/48053b8d-fc25-4702-be96-669452443cc6)