### PR TITLE
fix(blink.cmp): remove dedicated BlinkCmpDoc highlight

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -977,7 +977,6 @@ local function set_highlights()
 		AvanteReversedThirdTitle = { fg = palette.iris },
 
 		-- Saghen/blink.cmp
-		BlinkCmpDoc = { fg = palette.text },
 		BlinkCmpDocBorder = { fg = palette.highlight_high },
 		BlinkCmpGhostText = { fg = palette.muted },
 


### PR DESCRIPTION
The default `BlinkCmpDoc` highlight is linked to `NormalFloat`, which is a sensible default. However, due to overriding the default link with only `fg` provided, the `bg` is cleared and the documentation popup is indistinguishable from regular text.

This change is technically a no-op in terms of intended palette, because `NormalFloat` should already use `palette.text`, and only fixes the cleared `bg` bug.

Before:
![rose-pine-blink-doc](https://github.com/user-attachments/assets/edd5f1a4-d4f2-4276-8e3c-82b3b7305ffe)

After:
![rose-pine-blink-doc-fixed](https://github.com/user-attachments/assets/ee8dee3b-a741-4bcf-a7fa-7a75cb08c5e1)
