### PR TITLE
fix(blink.cmp): set BlinkCmpDoc background to palette.overlay

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -977,6 +977,8 @@ local function set_highlights()
 		AvanteReversedThirdTitle = { fg = palette.iris },
 
 		-- Saghen/blink.cmp
+		BlinkCmpDoc = { bg = palette.highlight_low },
+		BlinkCmpDocSeparator = { bg = palette.highlight_low },
 		BlinkCmpDocBorder = { fg = palette.highlight_high },
 		BlinkCmpGhostText = { fg = palette.muted },
 


### PR DESCRIPTION
Although the default of `NormalFloat` is a sensible value for the documentation float, it has the same highlight as `Pmenu`, which means that on narrow displays where the documentation window is shown below the completion menu, it is not always clear where the completion items end and where the documentation begins.

Setting the highlight to `palette.overlay` (compared to the default of `palette.surface`) adds a visual cue to separate the completion menu from the documentation window, without straying too much from the defaults.

Before:
![rose-pine-blink-doc](https://github.com/user-attachments/assets/0fc74908-5a02-458b-b05a-32832b863566)

After:
![rose-pine-blink-doc-fixed](https://github.com/user-attachments/assets/bdc86127-4a14-4a21-abfa-d5b365ee32d3)