### PR TITLE
feat: add `QuickFixLine`

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -121,7 +121,7 @@ local function set_highlights()
 		PmenuSel = { fg = palette.text, bg = palette.overlay },
 		PmenuThumb = { bg = palette.muted },
 		Question = { fg = palette.gold },
-		-- QuickFixLink = {},
+		QuickFixLine = { fg = palette.foam },
 		-- RedrawDebugNormal = {},
 		RedrawDebugClear = { fg = palette.base, bg = palette.gold },
 		RedrawDebugComposed = { fg = palette.base, bg = palette.pine },


### PR DESCRIPTION
This pull request adds the `QuickFixLine` highlight group (which seems to have been previously included as "`QuickFixLink`" and commented out). The built-in color for this group is `NvimLightCyan`, so `foam` seems to be a good choice.