### PR TITLE
feat(grug-far): add highlight groups for add/remove results

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -961,6 +961,8 @@ local function set_highlights()
 		GrugFarInputPlaceholder = { link = "Comment" },
 		GrugFarResultsActionMessage = { fg = palette.foam },
 		GrugFarResultsChangeIndicator = { fg = groups.git_change },
+		GrugFarResultsRemoveIndicator = { fg = groups.git_delete },
+		GrugFarResultsAddIndicator = { fg = groups.git_add },
 		GrugFarResultsHeader = { fg = palette.pine },
 		GrugFarResultsLineNo = { fg = palette.iris },
 		GrugFarResultsLineColumn = { link = "GrugFarResultsLineNo" },


### PR DESCRIPTION
**Fixes:** #365 

`grug-far`'s result list already shows `GrugFarResultsChangeIndicator`.
However, the `GrugFarResultsRemoveIndicator` and `GrugFarResultsAddIndicator` highlights were missing, causing the default values of `#d1242f` for *remove* and  `#055d20` for *add* to be used.

This PR adds the missing highlight groups, using the already utilized `groups.git_delete` & `groups.git_add` for the foreground.

### Before:
![Screenshot 2025-06-26 at 17 41 03](https://github.com/user-attachments/assets/a9a6ac82-cd0b-480d-ba29-f90029eabd5c)

### After:
![Screenshot 2025-06-26 at 17 53 16](https://github.com/user-attachments/assets/d4c02e93-b7f8-4fea-aa34-2b78c0648e95)
