### PR TITLE
feat: add AvantePromptInput highlight support

### DIFF
--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -978,8 +978,8 @@ local function set_highlights()
 		AvanteReversedSubtitle = { fg = palette.foam },
 		AvanteThirdTitle = { fg = palette.highlight_med, bg = palette.iris },
 		AvanteReversedThirdTitle = { fg = palette.iris },
-		AvantePromptInput = { bg = groups.panel, fg = palette.text },
-		AvantePromptInputBorder = groups.border,
+		AvantePromptInput = { fg = palette.text, bg = groups.panel },
+		AvantePromptInputBorder = { fg = groups.border },
 
 		-- Saghen/blink.cmp
 		BlinkCmpDoc = { bg = palette.highlight_low },

--- a/lua/rose-pine.lua
+++ b/lua/rose-pine.lua
@@ -978,6 +978,8 @@ local function set_highlights()
 		AvanteReversedSubtitle = { fg = palette.foam },
 		AvanteThirdTitle = { fg = palette.highlight_med, bg = palette.iris },
 		AvanteReversedThirdTitle = { fg = palette.iris },
+		AvantePromptInput = { bg = groups.panel, fg = palette.text },
+		AvantePromptInputBorder = groups.border,
 
 		-- Saghen/blink.cmp
 		BlinkCmpDoc = { bg = palette.highlight_low },


### PR DESCRIPTION
## Summary
- Add highlight support for `AvantePromptInput` and `AvantePromptInputBorder` in avante.nvim
- Follows the established styling pattern used by CMP and Blink completion menu inputs
- Uses `groups.panel` background with `palette.text` foreground for consistency

## Details
The avante.nvim plugin defines prompt input highlight groups that were previously unstyled in the rose-pine theme. This PR adds proper styling that matches the existing completion menu patterns:

- `AvantePromptInput`: Panel background with readable text foreground
- `AvantePromptInputBorder`: Standard border styling using `groups.border`

## Test
- I tested locally

| Before | After |
|--------|--------|
| <img width="357" height="87" alt="image" src="https://github.com/user-attachments/assets/a2c452b9-4dc6-4edf-9a0a-840446c938eb" /> | <img width="357" height="87" alt="image" src="https://github.com/user-attachments/assets/889f893a-5b1f-4643-b03d-35d302364c8a" /> | 
|Borders are too white and the background is the same in the popup and in the window |Borders are grey and the background in the popup is slightly lighter |