### PR TITLE
fix: README vim.pack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Install `rose-pine/neovim` using your favourite package manager:
 
 ```lua
 vim.pack.add({
-	src = "https://github.com/rose-pine/neovim",
-	name = "rose-pine"
+	{
+		src = "https://github.com/rose-pine/neovim",
+		name = "rose-pine",
+	},
 })
 require("rose-pine").setup()
 vim.cmd("colorscheme rose-pine")


### PR DESCRIPTION
The current `vim.pack` installation instructions are missing a table wrapping the pack spec, resulting on an error.
This PR fixes it to fit the current structure of `vim.pack.add`